### PR TITLE
fix: stream(legacy): include delta.reasoning alongside reasoning_summary

### DIFF
--- a/chatmock/utils.py
+++ b/chatmock/utils.py
@@ -409,7 +409,7 @@ def sse_translate_chat(
                             "choices": [
                                 {
                                     "index": 0,
-                                    "delta": {"reasoning_summary": delta_txt},
+                                    "delta": {"reasoning_summary": delta_txt, "reasoning": delta_txt},
                                     "finish_reason": None,
                                 }
                             ],


### PR DESCRIPTION
In legacy/current compatibility mode, stream both `delta.reasoning_summary` and `delta.reasoning` (string) for reasoning deltas. This ensures clients that expect `choices[0].delta.reasoning` as a string (e.g., OpenCode) render reasoning without schema errors. Without this, opencode and some other openai-compatible end point supported apps wouldnt show reasoning.

Change made only to legacy to avoid breakage with other software

The other way would be just to rename it to reasoning, but i believe this is preferable