### PR TITLE
routes: include all error attributes in user messages

### DIFF
--- a/chatmock/routes_ollama.py
+++ b/chatmock/routes_ollama.py
@@ -173,8 +173,15 @@ def ollama_chat() -> Response:
             err_body = {"raw": upstream.text}
         if verbose:
             print("/api/chat upstream error status=", upstream.status_code, " body:", json.dumps(err_body)[:2000])
+        error_obj = err_body.get("error", {}) or {}
+        base_msg = error_obj.get("message", "Upstream error")
+        attrs = []
+        for key, value in error_obj.items():
+            if key != "message":
+                attrs.append(f"{key}={value}")
+        combined_msg = base_msg + (" " + " ".join(attrs) if attrs else "")
         return (
-            jsonify({"error": (err_body.get("error", {}) or {}).get("message", "Upstream error")}),
+            jsonify({"error": combined_msg}),
             upstream.status_code,
         )
 

--- a/chatmock/routes_openai.py
+++ b/chatmock/routes_openai.py
@@ -102,8 +102,15 @@ def chat_completions() -> Response:
             err_body = {"raw": upstream.text}
         if verbose:
             print("Upstream error status=", upstream.status_code, " body:", json.dumps(err_body)[:2000])
+        error_obj = err_body.get("error", {}) or {}
+        base_msg = error_obj.get("message", "Upstream error")
+        attrs = []
+        for key, value in error_obj.items():
+            if key != "message":
+                attrs.append(f"{key}={value}")
+        combined_msg = base_msg + (" " + " ".join(attrs) if attrs else "")
         return (
-            jsonify({"error": {"message": (err_body.get("error", {}) or {}).get("message", "Upstream error")}}),
+            jsonify({"error": {"message": combined_msg}}),
             upstream.status_code,
         )
 
@@ -269,8 +276,15 @@ def completions() -> Response:
             err_body = json.loads(upstream.content.decode("utf-8", errors="ignore")) if upstream.content else {"raw": upstream.text}
         except Exception:
             err_body = {"raw": upstream.text}
+        error_obj = err_body.get("error", {}) or {}
+        base_msg = error_obj.get("message", "Upstream error")
+        attrs = []
+        for key, value in error_obj.items():
+            if key != "message":
+                attrs.append(f"{key}={value}")
+        combined_msg = base_msg + (" " + " ".join(attrs) if attrs else "")
         return (
-            jsonify({"error": {"message": (err_body.get("error", {}) or {}).get("message", "Upstream error")}}),
+            jsonify({"error": {"message": combined_msg}}),
             upstream.status_code,
         )
 


### PR DESCRIPTION
## Summary
- Combine all upstream error attributes into user-visible messages
- Preserve original error message as base, append key=value pairs for additional attributes
- Apply to both OpenAI and Ollama route error handlers