### PR TITLE
Create configuration file mechanism; prefer ~/.chatmock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# configs
+.env
+config.yaml
+

--- a/README.md
+++ b/README.md
@@ -53,9 +53,32 @@ Then, you can simply use the address and port as the baseURL as you require (htt
 
 **Reminder:** When setting a baseURL, make you sure you include /v1/ at the end of the URL if you're using this as a OpenAI compatible endpoint (e.g http://127.0.0.1:8000/v1)
 
+## CLI Reference
+
+Run `python chatmock.py -h` to see all commands. Running with no arguments will print help.
+
+- `login` --- Authorize with ChatGPT and store tokens.
+  - Options: `--no-browser`, `--verbose`
+- `serve` --- Run local OpenAI-compatible server.
+  - Options: `--config PATH`, `--host HOST`, `--port PORT`, `--verbose`,
+    `--debug-model NAME`, `--reasoning-effort {minimal,low,medium,high}`,
+    `--reasoning-summary {auto,concise,detailed,none}`,
+    `--reasoning-compat {legacy,o3,think-tags,current}`,
+    `--expose-reasoning-models`
+- `info` --- Print current stored tokens and derived account id.
+  - Options: `--json`
+- `diagnose` --- Print resolved configuration and sanity checks.
+  - Options: `--config PATH`
+
+## Troubleshooting
+
+- Port already in use but server still starts
+  - On many systems `localhost` resolves to IPv6 first (`::1`). You can have one service on `::1:PORT` and another on `127.0.0.1:PORT` at the same time. ChatMock now warns if it detects a listener on the other stack.
+  - Use `curl -4 http://localhost:8000` (IPv4) or `curl -6 http://localhost:8000` (IPv6), or target `http://127.0.0.1:8000` or `http://[::1]:8000` directly.
+
 # Examples
 
-### Python 
+### Python
 
 ```python
 from openai import OpenAI
@@ -104,15 +127,84 @@ curl http://127.0.0.1:8000/v1/chat/completions \
 
 # Customisation / Configuration
 
+### Config file (YAML preferred)
+
+You can configure the server host/port via a YAML config file. The following locations are searched in order (canonical name is `config.yaml`):
+
+- Home locations:
+  - If `~/.chatgpt-local` exists, that directory is used (legacy compatibility).
+  - Otherwise, the preferred location is `~/.chatmock`.
+  - You can override with `$CHATGPT_LOCAL_HOME` or `$CODEX_HOME`.
+
+You may also specify an explicit path with `--config` or the `CHATMOCK_CONFIG` environment variable.
+
+Example `config.yaml`:
+
+```
+server:
+  host: 127.0.0.1
+  port: 8000
+  # verbose: false
+  # expose_reasoning_models: false
+  # debug_model: null
+
+reasoning:
+  effort: medium      # minimal|low|medium|high
+  summary: auto       # auto|concise|detailed|none
+  compat: think-tags  # legacy|o3|think-tags
+
+oauth:
+  # Optionally override Codex OAuth client id (or set env CHATGPT_LOCAL_CLIENT_ID)
+  # client_id: "app_xxxxxxxxxxxxxxxxx"
+
+login:
+  # Bind host for the local OAuth helper (port is fixed at 1455)
+  bind_host: 127.0.0.1
+
+upstream:
+  # Optionally override the Responses API URL
+  # responses_url: https://chatgpt.com/backend-api/codex/responses
+
+instructions:
+  # Optional: path to custom instructions (prompt) file
+  # path: ./my-prompt.md
+```
+
+Usage examples:
+
+- CLI: `python chatmock.py serve --config ~/.chatmock/config.yaml`
+- GUI: Defaults are pre-filled from the config; you can still override in the UI.
+
+Precedence:
+- CLI flags override config values; config overrides environment variables; environment overrides built-in defaults.
+
+Note: On first run, a default commented `config.yaml` is created in the preferred home directory if none exists.
+
+### Auth file (auth.json) location
+
+ChatMock reads your auth tokens from these locations in order:
+
+- `$CHATMOCK_HOME/auth.json`
+- `$CHATGPT_LOCAL_HOME/auth.json`
+- `~/.chatmock/auth.json` (preferred)
+- `~/.chatgpt-local/auth.json` (legacy)
+- `$CODEX_HOME/auth.json` (Codex; read-only for ChatMock)
+- `~/.codex/auth.json` (Codex; read-only for ChatMock)
+
+When you run `chatmock login`, the auth file is written only to ChatMock-controlled locations, in this order: `$CHATMOCK_HOME`, `$CHATGPT_LOCAL_HOME`, then `~/.chatmock`.
+ChatMock never writes to Codex-managed locations (`$CODEX_HOME`, `~/.codex`) or `~/.chatgpt-local`.
+
 ### Thinking effort
 
 - `--reasoning-effort` (choice of minimal,low,medium,high)<br>
 GPT-5 has a configurable amount of "effort" it can put into thinking, which may cause it to take more time for a response to return, but may overall give a smarter answer. Applying this parameter after `serve` forces the server to use this reasoning effort by default, unless overrided by the API request with a different effort set. The default reasoning effort without setting this parameter is `medium`.
+You can also set this via config: `reasoning.effort` in `config.yaml`.
 
 ### Thinking summaries
 
 - `--reasoning-summary` (choice of auto,concise,detailed,none)<br>
 Models like GPT-5 do not return raw thinking content, but instead return thinking summaries. These can also be customised by you.
+You can also set this via config: `reasoning.summary`.
 
 ## Notes
 If you wish to have the fastest responses, I'd recommend setting `--reasoning-effort` to low, and `--reasoning-summary` to none.
@@ -129,4 +221,3 @@ The context size of this route is also larger than what you get access to in the
 ## Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=RayBytes/ChatMock&type=Timeline)](https://www.star-history.com/#RayBytes/ChatMock&Timeline)
-

--- a/chatmock/__init__.py
+++ b/chatmock/__init__.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
-from .app import create_app
-from .cli import main
+# Lightweight package init to avoid importing heavy dependencies at import time.
+# Access CLI and app via their modules:
+#   from chatmock.cli import main
+#   from chatmock.app import create_app
 
+__all__ = []

--- a/chatmock/cli.py
+++ b/chatmock/cli.py
@@ -7,22 +7,25 @@ import os
 import sys
 import webbrowser
 
-from .app import create_app
 from .config import CLIENT_ID_DEFAULT
-from .oauth import OAuthHTTPServer, OAuthHandler, REQUIRED_PORT, URL_BASE
+from .settings import load_config, resolve_server_host_port, resolve_login_options
 from .utils import eprint, get_home_dir, load_chatgpt_tokens, parse_jwt_claims, read_auth_file
 import os
 
 
 def cmd_login(no_browser: bool, verbose: bool) -> int:
     home_dir = get_home_dir()
+    cfg = load_config(None)
+    login_opts = resolve_login_options(cfg)
     client_id = CLIENT_ID_DEFAULT
     if not client_id:
         eprint("ERROR: No OAuth client id configured. Set CHATGPT_LOCAL_CLIENT_ID.")
         return 1
 
+    # Lazy import to avoid requiring certifi when only running non-login commands
+    from .oauth import OAuthHTTPServer, OAuthHandler, REQUIRED_PORT, URL_BASE
     try:
-        bind_host = os.getenv("CHATGPT_LOCAL_LOGIN_BIND", "127.0.0.1")
+        bind_host = login_opts.get("bind_host", "127.0.0.1")
         httpd = OAuthHTTPServer((bind_host, REQUIRED_PORT), OAuthHandler, home_dir=home_dir, client_id=client_id, verbose=verbose)
     except OSError as e:
         eprint(f"ERROR: {e}")
@@ -97,6 +100,34 @@ def cmd_serve(
     debug_model: str | None,
     expose_reasoning_models: bool,
 ) -> int:
+    # Lazy import to avoid requiring Flask for non-serve commands
+    from .app import create_app
+    from .utils import eprint
+    import socket
+
+    def _is_listening(addr: str, p: int) -> bool:
+        try:
+            with socket.create_connection((addr, p), timeout=0.2):
+                return True
+        except Exception:
+            return False
+
+    # Preflight: warn about possible dual-stack confusion
+    try:
+        if host in ("127.0.0.1", "0.0.0.0"):
+            if _is_listening("::1", port):
+                eprint(
+                    f"Warning: Another service is listening on [::1]:{port} (IPv6). "
+                    f"This server will bind {host}:{port} (IPv4). 'localhost' may resolve to ::1; use 127.0.0.1 explicitly."
+                )
+        elif host in ("::1", "::"):
+            if _is_listening("127.0.0.1", port):
+                eprint(
+                    f"Warning: Another service is listening on 127.0.0.1:{port} (IPv4). "
+                    f"This server will bind {host}:{port} (IPv6). 'localhost' may resolve to ::1; use ::1 explicitly."
+                )
+    except Exception:
+        pass
     app = create_app(
         verbose=verbose,
         reasoning_effort=reasoning_effort,
@@ -111,39 +142,50 @@ def cmd_serve(
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="ChatGPT Local: login & OpenAI-compatible proxy")
+    parent_cfg = argparse.ArgumentParser(add_help=False)
+    parent_cfg.add_argument("--config", help="Path to YAML config file")
+
+    parser = argparse.ArgumentParser(
+        description="ChatGPT Local: login & OpenAI-compatible proxy",
+        epilog=(
+            "Use 'python chatmock.py <command> -h' for command-specific options.\n"
+            "Global options: --config PATH. Default config is '~/.chatmock/config.yaml'\n"
+            "(or '~/.chatgpt-local/config.yaml' if that directory exists)."
+        ),
+        parents=[parent_cfg],
+    )
     sub = parser.add_subparsers(dest="command", required=True)
 
     p_login = sub.add_parser("login", help="Authorize with ChatGPT and store tokens")
     p_login.add_argument("--no-browser", action="store_true", help="Do not open the browser automatically")
     p_login.add_argument("--verbose", action="store_true", help="Enable verbose logging")
 
-    p_serve = sub.add_parser("serve", help="Run local OpenAI-compatible server")
-    p_serve.add_argument("--host", default="127.0.0.1")
-    p_serve.add_argument("--port", type=int, default=8000)
+    p_serve = sub.add_parser("serve", help="Run local OpenAI-compatible server", parents=[parent_cfg])
+    p_serve.add_argument("--host", default=None)
+    p_serve.add_argument("--port", type=int, default=None)
     p_serve.add_argument("--verbose", action="store_true", help="Enable verbose logging")
     p_serve.add_argument(
         "--debug-model",
         dest="debug_model",
-        default=os.getenv("CHATGPT_LOCAL_DEBUG_MODEL"),
+        default=None,
         help="Forcibly override requested 'model' with this value",
     )
     p_serve.add_argument(
         "--reasoning-effort",
         choices=["minimal", "low", "medium", "high"],
-        default=os.getenv("CHATGPT_LOCAL_REASONING_EFFORT", "medium").lower(),
+        default=None,
         help="Reasoning effort level for Responses API (default: medium)",
     )
     p_serve.add_argument(
         "--reasoning-summary",
         choices=["auto", "concise", "detailed", "none"],
-        default=os.getenv("CHATGPT_LOCAL_REASONING_SUMMARY", "auto").lower(),
+        default=None,
         help="Reasoning summary verbosity (default: auto)",
     )
     p_serve.add_argument(
         "--reasoning-compat",
         choices=["legacy", "o3", "think-tags", "current"],
-        default=os.getenv("CHATGPT_LOCAL_REASONING_COMPAT", "think-tags").lower(),
+        default=None,
         help=(
             "Compatibility mode for exposing reasoning to clients (legacy|o3|think-tags). "
             "'current' is accepted as an alias for 'legacy'"
@@ -152,7 +194,7 @@ def main() -> None:
     p_serve.add_argument(
         "--expose-reasoning-models",
         action="store_true",
-        default=os.getenv("CHATGPT_LOCAL_EXPOSE_REASONING_MODELS", "").strip().lower() in ("1", "true", "yes", "on"),
+        default=None,
         help=(
             "Expose gpt-5 reasoning effort variants (minimal|low|medium|high) as separate models from /v1/models. "
             "This allows choosing effort via model selection in compatible UIs."
@@ -162,24 +204,62 @@ def main() -> None:
     p_info = sub.add_parser("info", help="Print current stored tokens and derived account id")
     p_info.add_argument("--json", action="store_true", help="Output raw auth.json contents")
 
+    p_diag = sub.add_parser("diagnose", help="Print resolved configuration and sanity checks", parents=[parent_cfg])
+
+    # If no arguments were provided, show help instead of raising
+    if len(sys.argv) == 1:
+        parser.print_help()
+        sys.exit(2)
+
     args = parser.parse_args()
 
     if args.command == "login":
         sys.exit(cmd_login(no_browser=args.no_browser, verbose=args.verbose))
     elif args.command == "serve":
+        from .settings import find_config_file as _find_cfg, ensure_default_config_created
+        explicit_cfg = getattr(args, "config", None)
+        if not explicit_cfg:
+            # Create a default config in the preferred home if none exists
+            ensure_default_config_created()
+        cfg_path = _find_cfg(explicit_cfg)
+        cfg = load_config(explicit_cfg)
+        host, port = resolve_server_host_port(cfg, getattr(args, "host", None), getattr(args, "port", None))
+        from .settings import resolve_runtime_options
+        opts = resolve_runtime_options(
+            cfg,
+            arg_verbose=getattr(args, "verbose", None),
+            arg_effort=getattr(args, "reasoning_effort", None),
+            arg_summary=getattr(args, "reasoning_summary", None),
+            arg_compat=getattr(args, "reasoning_compat", None),
+            arg_debug_model=getattr(args, "debug_model", None),
+            arg_expose_reasoning_models=getattr(args, "expose_reasoning_models", None),
+        )
+        # Startup banner with resolved config path and URL
+        from .utils import eprint
+        if cfg_path is None:
+            eprint(f"Starting server at http://{host}:{port} (config: <none>)")
+        else:
+            eprint(f"Starting server at http://{host}:{port} (config: {cfg_path})")
         sys.exit(
             cmd_serve(
-                host=args.host,
-                port=args.port,
-                verbose=args.verbose,
-                reasoning_effort=args.reasoning_effort,
-                reasoning_summary=args.reasoning_summary,
-                reasoning_compat=args.reasoning_compat,
-                debug_model=args.debug_model,
-                expose_reasoning_models=args.expose_reasoning_models,
+                host=host,
+                port=port,
+                verbose=opts["verbose"],
+                reasoning_effort=opts["reasoning_effort"],
+                reasoning_summary=opts["reasoning_summary"],
+                reasoning_compat=opts["reasoning_compat"],
+                debug_model=opts["debug_model"],
+                expose_reasoning_models=opts["expose_reasoning_models"],
             )
         )
     elif args.command == "info":
+        # Show which config would be used
+        from .settings import find_config_file as _find_cfg, ensure_default_config_created
+        ensure_default_config_created()
+        cfg_path = _find_cfg(None)
+        if not getattr(args, "json", False):
+            print(f"Config file: {cfg_path or '<none found>'}")
+
         auth = read_auth_file()
         if getattr(args, "json", False):
             print(json.dumps(auth or {}, indent=2))
@@ -211,6 +291,71 @@ def main() -> None:
         print(f"  • Plan: {plan}")
         if account_id:
             print(f"  • Account ID: {account_id}")
+        sys.exit(0)
+    elif args.command == "diagnose":
+        from .settings import find_config_file, resolve_runtime_options, resolve_login_options, ensure_default_config_created
+        if not getattr(args, "config", None):
+            ensure_default_config_created()
+        cfg = load_config(getattr(args, "config", None))
+        cfg_path = find_config_file(getattr(args, "config", None))
+        host, port = resolve_server_host_port(cfg, None, None)
+        opts = resolve_runtime_options(cfg)
+        login_opts = resolve_login_options(cfg)
+
+        # instructions path resolution (mirror of config.read_base_instructions)
+        instr = (cfg.get("instructions") or {}) if isinstance(cfg, dict) else {}
+        custom_instr = instr.get("path") if isinstance(instr, dict) else None
+        instr_path = None
+        from pathlib import Path
+        import sys as _sys
+        if isinstance(custom_instr, str) and custom_instr.strip():
+            p = Path(custom_instr).expanduser()
+            if not p.is_absolute():
+                p = Path.cwd() / p
+            instr_path = p if p.exists() else None
+        if instr_path is None:
+            candidates = [
+                Path(__file__).parent.parent / "prompt.md",
+                Path(__file__).parent / "prompt.md",
+                Path(getattr(_sys, "_MEIPASS", "")) / "prompt.md" if getattr(_sys, "_MEIPASS", None) else None,
+                Path.cwd() / "prompt.md",
+            ]
+            for p in candidates:
+                if p and p.exists():
+                    instr_path = p
+                    break
+
+        oauth = (cfg.get("oauth") or {}) if isinstance(cfg, dict) else {}
+        client_id = oauth.get("client_id") or os.getenv("CHATGPT_LOCAL_CLIENT_ID") or "app_EMoamEEZ73f0CkXaXp7hrann"
+        upstream = (cfg.get("upstream") or {}) if isinstance(cfg, dict) else {}
+        responses_url = upstream.get("responses_url") or "https://chatgpt.com/backend-api/codex/responses"
+
+        # Optional: compute instructions hash
+        instr_hash = None
+        instr_size = None
+        if instr_path and instr_path.exists():
+            try:
+                import hashlib
+                data = instr_path.read_bytes()
+                instr_hash = hashlib.sha256(data).hexdigest()[:16]
+                instr_size = len(data)
+            except Exception:
+                pass
+
+        print("Config diagnose")
+        print(f"  • Config file: {cfg_path or '<none found>'}")
+        print(f"  • Server: http://{host}:{port}")
+        print(f"  • Verbose: {opts['verbose']}")
+        print(f"  • Reasoning: effort={opts['reasoning_effort']} summary={opts['reasoning_summary']} compat={opts['reasoning_compat']}")
+        print(f"  • Debug model: {opts['debug_model'] or '-'}  Expose variants: {opts['expose_reasoning_models']}")
+        print(f"  • Login bind host: {login_opts['bind_host']}")
+        print(f"  • OAuth client id: {client_id}")
+        print(f"  • Upstream Responses URL: {responses_url}")
+        if instr_path:
+            extra = f" (sha256[:16]={instr_hash}, bytes={instr_size})" if instr_hash else ""
+            print(f"  • Instructions file: {instr_path}{extra}")
+        else:
+            print("  • Instructions file: <not found>")
         sys.exit(0)
     else:
         parser.error("Unknown command")

--- a/chatmock/config.py
+++ b/chatmock/config.py
@@ -3,14 +3,44 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
+from .settings import load_config
 
 
-CLIENT_ID_DEFAULT = os.getenv("CHATGPT_LOCAL_CLIENT_ID") or "app_EMoamEEZ73f0CkXaXp7hrann"
+_cfg = {}
+try:
+    _cfg = load_config(None)
+except Exception:
+    _cfg = {}
 
-CHATGPT_RESPONSES_URL = "https://chatgpt.com/backend-api/codex/responses"
+CLIENT_ID_DEFAULT = (
+    (_cfg.get("oauth", {}) or {}).get("client_id")
+    or os.getenv("CHATGPT_LOCAL_CLIENT_ID")
+    or "app_EMoamEEZ73f0CkXaXp7hrann"
+)
+
+CHATGPT_RESPONSES_URL = (
+    (_cfg.get("upstream", {}) or {}).get("responses_url")
+    or "https://chatgpt.com/backend-api/codex/responses"
+)
 
 
 def read_base_instructions() -> str:
+    # 0) Config override: instructions.path
+    try:
+        instr_cfg = (_cfg.get("instructions") or {}) if isinstance(_cfg, dict) else {}
+        custom_path = instr_cfg.get("path") if isinstance(instr_cfg, dict) else None
+        if isinstance(custom_path, str) and custom_path.strip():
+            p = Path(custom_path).expanduser()
+            if not p.is_absolute():
+                p = Path.cwd() / p
+            if p.exists():
+                content = p.read_text(encoding="utf-8")
+                if isinstance(content, str) and content.strip():
+                    return content
+    except Exception:
+        pass
+
+    # 1) Default locations
     candidates = [
         Path(__file__).parent.parent / "prompt.md",
         Path(__file__).parent / "prompt.md",

--- a/chatmock/settings.py
+++ b/chatmock/settings.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+
+def _load_yaml(path: Path) -> Dict[str, Any]:
+    try:
+        import yaml  # type: ignore
+    except Exception:
+        raise RuntimeError(f"YAML config '{path}' requires PyYAML. Install 'pyyaml'.")
+    with path.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    return data or {}
+
+
+def find_config_file(explicit: Optional[str] = None) -> Optional[Path]:
+    """Locate a YAML configuration file.
+
+    Search order (canonical name is 'config.yaml'):
+      1) explicit path (CLI flag) or CHATMOCK_CONFIG
+      2) In one of: CHATGPT_LOCAL_HOME, CODEX_HOME, ~/.chatgpt-local -> config.yaml
+    Project working directory is intentionally NOT searched.
+    """
+    # 1) explicit path
+    if explicit:
+        p = Path(explicit).expanduser()
+        return p if p.exists() else None
+
+    # 1b) env var explicit
+    env_path = os.getenv("CHATMOCK_CONFIG")
+    if env_path:
+        p = Path(env_path).expanduser()
+        if p.exists():
+            return p
+
+    # 2) Home-like location (canonical name only)
+    canonical = "config.yaml"
+    base = get_config_home_dir()
+    p = Path(base) / canonical
+    if p.exists():
+        return p
+
+    # No legacy fallbacks: only config.yaml is recognized
+    
+    return None
+
+
+def load_config(explicit: Optional[str] = None) -> Dict[str, Any]:
+    path = find_config_file(explicit)
+    if not path:
+        return {}
+    # Accept .yaml/.yml, or files without extension that contain YAML
+    return _load_yaml(path)
+
+
+def get_config_home_dir() -> Path:
+    """Return the preferred directory for config files.
+
+    Preference:
+      1) If CHATMOCK_HOME is set, use it.
+      2) Else if CHATGPT_LOCAL_HOME is set, use it.
+      3) Else if ~/.chatgpt-local exists, use it (legacy, read-compat).
+      4) Else use ~/.chatmock (new default).
+    """
+    env_home = os.getenv("CHATMOCK_HOME") or os.getenv("CHATGPT_LOCAL_HOME")
+    if env_home:
+        return Path(env_home).expanduser()
+    legacy_dir = Path(os.path.expanduser("~/.chatgpt-local"))
+    if legacy_dir.exists():
+        return legacy_dir
+    return Path(os.path.expanduser("~/.chatmock"))
+
+
+def ensure_default_config_created() -> Path | None:
+    """Ensure a default commented config.yaml exists in the config home.
+
+    If a config already exists anywhere discoverable, do nothing.
+    Returns the path to the created file, or None if not created.
+    """
+    if find_config_file(None):
+        return None
+    base = get_config_home_dir()
+    try:
+        base.mkdir(parents=True, exist_ok=True)
+    except Exception:
+        return None
+    cfg_path = base / "config.yaml"
+    if cfg_path.exists():
+        return None
+    try:
+        cfg_path.write_text(
+            """
+# ChatMock configuration (create/edit this file to customize)
+
+server:
+  # Bind host (e.g., 127.0.0.1 or 0.0.0.0)
+  host: 127.0.0.1
+  # Listening port
+  port: 8000
+  # Enable verbose logging
+  # verbose: false
+  # Expose gpt-5 reasoning effort variants as separate models
+  # expose_reasoning_models: false
+  # Force all requests to use a specific model name
+  # debug_model: null
+
+reasoning:
+  # minimal | low | medium | high
+  effort: medium
+  # auto | concise | detailed | none
+  summary: auto
+  # legacy | o3 | think-tags ("current" is alias of legacy)
+  compat: think-tags
+
+login:
+  # Bind host for local OAuth redirect helper
+  bind_host: 127.0.0.1
+
+upstream:
+  # Override Responses API URL if needed
+  # responses_url: https://chatgpt.com/backend-api/codex/responses
+
+instructions:
+  # Path to a custom prompt instructions file
+  # path: ./my-prompt.md
+""".lstrip(),
+            encoding="utf-8",
+        )
+        return cfg_path
+    except Exception:
+        return None
+
+
+def resolve_server_host_port(
+    config: Dict[str, Any],
+    arg_host: Optional[str],
+    arg_port: Optional[int],
+) -> Tuple[str, int]:
+    server = (config.get("server") or {}) if isinstance(config, dict) else {}
+    # precedence: CLI args > config > env > defaults
+    host = (
+        arg_host
+        or server.get("host")
+        or os.getenv("HOST")
+        or "127.0.0.1"
+    )
+    port_val = arg_port
+    if port_val is None:
+        cfg_port = server.get("port") if isinstance(server, dict) else None
+        env_port = os.getenv("PORT")
+        if isinstance(cfg_port, int):
+            port_val = cfg_port
+        elif env_port and env_port.isdigit():
+            port_val = int(env_port)
+        else:
+            port_val = 8000
+    return str(host), int(port_val)
+
+
+def _get_bool_env(name: str, default: bool = False) -> bool:
+    val = os.getenv(name)
+    if val is None:
+        return default
+    return str(val).strip().lower() in ("1", "true", "yes", "on")
+
+
+def resolve_runtime_options(
+    config: Dict[str, Any],
+    *,
+    arg_verbose: Optional[bool] = None,
+    arg_effort: Optional[str] = None,
+    arg_summary: Optional[str] = None,
+    arg_compat: Optional[str] = None,
+    arg_debug_model: Optional[str] = None,
+    arg_expose_reasoning_models: Optional[bool] = None,
+) -> Dict[str, Any]:
+    server = config.get("server") if isinstance(config, dict) else {}
+    reasoning = config.get("reasoning") if isinstance(config, dict) else {}
+    if not isinstance(server, dict):
+        server = {}
+    if not isinstance(reasoning, dict):
+        reasoning = {}
+
+    verbose = bool(arg_verbose) if arg_verbose else bool(server.get("verbose", _get_bool_env("VERBOSE", False)))
+    debug_model = arg_debug_model or str(server.get("debug_model") or os.getenv("CHATGPT_LOCAL_DEBUG_MODEL") or "") or None
+
+    effort = (arg_effort or str(reasoning.get("effort") or os.getenv("CHATGPT_LOCAL_REASONING_EFFORT") or "medium")).lower()
+    summary = (arg_summary or str(reasoning.get("summary") or os.getenv("CHATGPT_LOCAL_REASONING_SUMMARY") or "auto")).lower()
+    compat = (arg_compat or str(reasoning.get("compat") or os.getenv("CHATGPT_LOCAL_REASONING_COMPAT") or "think-tags")).lower()
+
+    expose_reasoning_models = (
+        arg_expose_reasoning_models
+        if arg_expose_reasoning_models is not None
+        else bool(server.get("expose_reasoning_models", _get_bool_env("CHATGPT_LOCAL_EXPOSE_REASONING_MODELS", False)))
+    )
+
+    return {
+        "verbose": verbose,
+        "debug_model": debug_model,
+        "reasoning_effort": effort,
+        "reasoning_summary": summary,
+        "reasoning_compat": compat,
+        "expose_reasoning_models": expose_reasoning_models,
+    }
+
+
+def resolve_login_options(config: Dict[str, Any]) -> Dict[str, Any]:
+    login = (config.get("login") or {}) if isinstance(config, dict) else {}
+    if not isinstance(login, dict):
+        login = {}
+    bind_host = str(login.get("bind_host") or os.getenv("CHATGPT_LOCAL_LOGIN_BIND") or "127.0.0.1")
+    return {"bind_host": bind_host}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,0 +1,54 @@
+# ChatMock configuration (YAML)
+# Canonical filename: config.yaml
+# Place a copy as config.yaml in your project root, or in one of:
+#   $CHATGPT_LOCAL_HOME/config.yaml
+#   $CODEX_HOME/config.yaml
+#   ~/.chatgpt-local/config.yaml
+#
+# This file is an example and is not loaded as-is.
+
+server:
+  # Bind host (e.g., 127.0.0.1 or 0.0.0.0)
+  host: 127.0.0.1
+
+  # Listening port
+  port: 8000
+
+  # Enable verbose logging
+  # verbose: false
+
+  # Expose gpt-5 reasoning effort variants as separate models
+  # expose_reasoning_models: false
+
+  # Force all requests to use a specific model name
+  # debug_model: null
+
+reasoning:
+  # minimal | low | medium | high
+  effort: medium
+
+  # auto | concise | detailed | none
+  summary: auto
+
+  # legacy | o3 | think-tags ("current" is accepted as alias of legacy)
+  compat: think-tags
+
+# OAuth / Login options
+oauth:
+  # Optional: override Codex client id (normally set via env CHATGPT_LOCAL_CLIENT_ID)
+  # client_id: "app_xxxxxxxxxxxxxxxxx"
+
+login:
+  # Bind host for local OAuth redirect helper
+  bind_host: 127.0.0.1
+
+# Upstream overrides
+upstream:
+  # Override Responses API URL if needed
+  # responses_url: https://chatgpt.com/backend-api/codex/responses
+
+# Instructions override
+instructions:
+  # Path to a custom prompt instructions file (defaults to prompt.md in repo/app)
+  # Relative paths resolve from current working directory
+  # path: ./my-prompt.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ markupsafe==3.0.2
 requests==2.32.5
 urllib3==2.5.0
 werkzeug==3.1.3
+pyyaml==6.0.2

--- a/scripts/selftest.py
+++ b/scripts/selftest.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PY = shutil.which("python3") or sys.executable
+
+
+def run(cmd: list[str], *, cwd: Path | None = None, env: dict[str, str] | None = None) -> tuple[int, str, str]:
+    p = subprocess.run(cmd, cwd=cwd, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    return p.returncode, p.stdout, p.stderr
+
+
+def clean_output(s: str) -> str:
+    # Drop Homebrew/pyenv noise lines at top, keep diagnose body
+    lines = [ln for ln in s.splitlines() if not ln.startswith('/opt/homebrew/') and 'pyenv:' not in ln]
+    return '\n'.join(lines)
+
+
+def expect_contains(name: str, haystack: str, needle: str) -> None:
+    if needle not in haystack:
+        raise AssertionError(f"[{name}] Missing expected text: {needle}\n--- output ---\n{haystack}\n--------------")
+
+
+def test_repo_config() -> None:
+    code, out, err = run([PY, str(REPO_ROOT / 'chatmock.py'), 'diagnose'])
+    out = clean_output(out)
+    assert code == 0, f"diagnose failed: {err or out}"
+    expect_contains('repo-config', out, 'Config diagnose')
+    expect_contains('repo-config', out, 'Server: http://')
+    expect_contains('repo-config', out, 'Instructions file:')
+    expect_contains('repo-config', out, 'prompt.md')
+
+
+def test_explicit_config() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        d = Path(td)
+        (d / 'my-prompt.md').write_text('SELFTEST_PROMPT_123', encoding='utf-8')
+        (d / 'cfg.yaml').write_text(
+            '\n'.join([
+                'server:',
+                '  host: 0.0.0.0',
+                '  port: 8044',
+                'reasoning:',
+                '  effort: low',
+                '  summary: none',
+                '  compat: legacy',
+                'login:',
+                '  bind_host: 0.0.0.0',
+                'oauth:',
+                '  client_id: app_SELFTEST',
+                'upstream:',
+                '  responses_url: https://example.invalid/responses',
+                'instructions:',
+                '  path: ./my-prompt.md',
+            ]),
+            encoding='utf-8',
+        )
+        code, out, err = run([PY, str(REPO_ROOT / 'chatmock.py'), 'diagnose', '--config', str(d / 'cfg.yaml')], cwd=d)
+        out = clean_output(out)
+        assert code == 0, f"diagnose explicit failed: {err or out}"
+        expect_contains('explicit-config', out, 'Server: http://0.0.0.0:8044')
+        expect_contains('explicit-config', out, 'effort=low')
+        expect_contains('explicit-config', out, 'summary=none')
+        expect_contains('explicit-config', out, 'compat=legacy')
+        expect_contains('explicit-config', out, 'Login bind host: 0.0.0.0')
+        expect_contains('explicit-config', out, 'OAuth client id: app_SELFTEST')
+        expect_contains('explicit-config', out, 'Upstream Responses URL: https://example.invalid/responses')
+        expect_contains('explicit-config', out, "Instructions file:")
+        expect_contains('explicit-config', out, "my-prompt.md")
+
+
+def test_no_pwd_config() -> None:
+    # Ensure PWD config is not picked up implicitly
+    with tempfile.TemporaryDirectory() as td:
+        d = Path(td)
+        (d / 'config.yaml').write_text('\n'.join(['server:', '  host: 127.0.0.1', '  port: 8099']), encoding='utf-8')
+        env = os.environ.copy()
+        env['PYTHONPATH'] = str(REPO_ROOT)
+        code, out, err = run([PY, '-m', 'chatmock.cli', 'diagnose'], cwd=d, env=env)
+        out = clean_output(out)
+        assert code == 0, f"diagnose failed: {err or out}"
+        # Should show default 127.0.0.1:8000 since PWD config is ignored
+        expect_contains('no-pwd-config', out, 'Server: http://127.0.0.1:8000')
+
+
+def main() -> None:
+    tests = [
+        ('repo-config', test_repo_config),
+        ('explicit-config', test_explicit_config),
+        ('no-pwd-config', test_no_pwd_config),
+    ]
+    failures = 0
+    for name, fn in tests:
+        try:
+            fn()
+            print(f"PASS {name}")
+        except Exception as e:
+            failures += 1
+            print(f"FAIL {name}: {e}")
+    if failures:
+        sys.exit(1)
+    print('All self-tests passed')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Create configuration file mechanism; prefer ~/.chatmock; CLI/docs; port warning; hygiene


- Configuration
  - Add canonical `config.yaml` mechanism with explicit `--config` support.
  - Discover config from `--config`/`CHATMOCK_CONFIG` or home dir (prefer `~/.chatmock`; use `~/.chatgpt-local` if it exists; `$CHATMOCK_HOME`/`$CHATGPT_LOCAL_HOME` override).
  - Auto-create a commented default `config.yaml` in the preferred home on first run (serve/info/diagnose) if none exists.
  - Log the resolved server URL and config path at startup; `info` prints the config path (non-JSON).
  - Include `config.example.yaml` in-repo as a sample; update README examples and docs.

- CLI UX & Docs
  - Running with no args shows help (no traceback).
  - Document global `--config` at top level; `serve`/`diagnose` inherit it.
  - Add concise CLI reference to README.

- Port clarity
  - Preflight warning if the other IP stack is already listening on the same port (IPv4 vs IPv6) to avoid “localhost” ambiguity.

- Auth home alignment
  - Prefer `~/.chatmock` for reads/writes; support `$CHATMOCK_HOME`; legacy locations still read as fallback (Codex paths read-only).
  - Write auth only during `login`.

- Repo hygiene
  - Add `.gitignore` for Python artifacts and common noise; stop tracking `__pycache__`/bytecode.
  - Update self-test to reflect config behavior.