### PR TITLE
Fix tool call argument serialization issue

### DIFF
--- a/chatmock/utils.py
+++ b/chatmock/utils.py
@@ -323,7 +323,16 @@ def sse_translate_chat(
                     if isinstance(eff_params, (dict, list)):
                         args_str = json.dumps(eff_params)
                     elif isinstance(eff_params, str):
-                        args_str = json.dumps({"query": eff_params})
+                        # Try to parse as JSON first
+                        try:
+                            parsed = json.loads(eff_params)
+                            if isinstance(parsed, (dict, list)):
+                                args_str = json.dumps(parsed)  # Use parsed object directly
+                            else:
+                                args_str = json.dumps({"query": eff_params})  # Primitive value, wrap in query
+                        except (json.JSONDecodeError, ValueError):
+                            # Not valid JSON, treat as plain string
+                            args_str = json.dumps({"query": eff_params})
                     else:
                         args_str = "{}"
                     if call_id not in ws_index:
@@ -405,7 +414,16 @@ def sse_translate_chat(
                         if isinstance(eff_args, (dict, list)):
                             args = json.dumps(eff_args)
                         elif isinstance(eff_args, str):
-                            args = json.dumps({"query": eff_args})
+                            # Try to parse as JSON first
+                            try:
+                                parsed = json.loads(eff_args)
+                                if isinstance(parsed, (dict, list)):
+                                    args = json.dumps(parsed)  # Use parsed object directly
+                                else:
+                                    args = json.dumps({"query": eff_args})  # Primitive value, wrap in query
+                            except (json.JSONDecodeError, ValueError):
+                                # Not valid JSON, treat as plain string
+                                args = json.dumps({"query": eff_args})
                         else:
                             args = "{}"
                     except Exception:

--- a/chatmock/utils.py
+++ b/chatmock/utils.py
@@ -267,15 +267,13 @@ def sse_translate_chat(
         if isinstance(eff_args, (dict, list)):
             return json.dumps(eff_args)
         elif isinstance(eff_args, str):
-            # Try to parse as JSON first
             try:
                 parsed = json.loads(eff_args)
                 if isinstance(parsed, (dict, list)):
-                    return json.dumps(parsed)  # Use parsed object directly
+                    return json.dumps(parsed) 
                 else:
-                    return json.dumps({"query": eff_args})  # Primitive value, wrap in query
+                    return json.dumps({"query": eff_args})  
             except (json.JSONDecodeError, ValueError):
-                # Not valid JSON, treat as plain string
                 return json.dumps({"query": eff_args})
         else:
             return "{}"

--- a/chatmock/utils.py
+++ b/chatmock/utils.py
@@ -254,6 +254,32 @@ def sse_translate_chat(
     ws_index: dict[str, int] = {}
     ws_next_index: int = 0
     
+    def _serialize_tool_args(eff_args: Any) -> str:
+        """
+        Serialize tool call arguments with proper JSON handling.
+        
+        Args:
+            eff_args: Arguments to serialize (dict, list, str, or other)
+            
+        Returns:
+            JSON string representation of the arguments
+        """
+        if isinstance(eff_args, (dict, list)):
+            return json.dumps(eff_args)
+        elif isinstance(eff_args, str):
+            # Try to parse as JSON first
+            try:
+                parsed = json.loads(eff_args)
+                if isinstance(parsed, (dict, list)):
+                    return json.dumps(parsed)  # Use parsed object directly
+                else:
+                    return json.dumps({"query": eff_args})  # Primitive value, wrap in query
+            except (json.JSONDecodeError, ValueError):
+                # Not valid JSON, treat as plain string
+                return json.dumps({"query": eff_args})
+        else:
+            return "{}"
+    
     def _extract_usage(evt: Dict[str, Any]) -> Dict[str, int] | None:
         try:
             usage = (evt.get("response") or {}).get("usage")
@@ -320,21 +346,7 @@ def sse_translate_chat(
                         except Exception:
                             pass
                     eff_params = ws_state.get(call_id, params if isinstance(params, (dict, list, str)) else {})
-                    if isinstance(eff_params, (dict, list)):
-                        args_str = json.dumps(eff_params)
-                    elif isinstance(eff_params, str):
-                        # Try to parse as JSON first
-                        try:
-                            parsed = json.loads(eff_params)
-                            if isinstance(parsed, (dict, list)):
-                                args_str = json.dumps(parsed)  # Use parsed object directly
-                            else:
-                                args_str = json.dumps({"query": eff_params})  # Primitive value, wrap in query
-                        except (json.JSONDecodeError, ValueError):
-                            # Not valid JSON, treat as plain string
-                            args_str = json.dumps({"query": eff_params})
-                    else:
-                        args_str = "{}"
+                    args_str = _serialize_tool_args(eff_params)
                     if call_id not in ws_index:
                         ws_index[call_id] = ws_next_index
                         ws_next_index += 1
@@ -411,21 +423,7 @@ def sse_translate_chat(
                             pass
                     eff_args = ws_state.get(call_id, raw_args if isinstance(raw_args, (dict, list, str)) else {})
                     try:
-                        if isinstance(eff_args, (dict, list)):
-                            args = json.dumps(eff_args)
-                        elif isinstance(eff_args, str):
-                            # Try to parse as JSON first
-                            try:
-                                parsed = json.loads(eff_args)
-                                if isinstance(parsed, (dict, list)):
-                                    args = json.dumps(parsed)  # Use parsed object directly
-                                else:
-                                    args = json.dumps({"query": eff_args})  # Primitive value, wrap in query
-                            except (json.JSONDecodeError, ValueError):
-                                # Not valid JSON, treat as plain string
-                                args = json.dumps({"query": eff_args})
-                        else:
-                            args = "{}"
+                        args = _serialize_tool_args(eff_args)
                     except Exception:
                         args = "{}"
                     if item.get("type") == "web_search_call" and verbose and vlog:


### PR DESCRIPTION
# Fix tool call argument serialization issue

## Problem Description
Tool call arguments were being incorrectly serialized when passed as JSON strings, causing them to be wrapped in an unnecessary `query` field instead of being parsed and used directly.

### Before (Broken):
```json
{
  "query": "{\"operation\":\"write\",\"todoList\":[{\"id\":1,\"title\":\"test\"}]}"
}
```

### After (Fixed):
```json
{
  "operation": "write",
  "todoList": [
    {
      "id": 1,
      "title": "test"
    }
  ]
}
```

## Root Cause
The issue was in the `sse_translate_chat` function in utils.py at two locations:
1. **Lines ~324-328**: Web search call processing
2. **Lines ~405-409**: Function call output processing

The original logic treated all string arguments the same way:
```python
elif isinstance(eff_args, str):
    args = json.dumps({"query": eff_args})  # Always wrapped in query
```

This caused valid JSON strings to be double-wrapped instead of being parsed and used directly.

## Solution
Enhanced the argument serialization logic to:
1. **Parse JSON strings first** - Check if string arguments are valid JSON
2. **Use parsed objects directly** - If parsing succeeds and results in dict/list, serialize directly
3. **Preserve query wrapping for plain strings** - Only wrap non-JSON strings in `query` field

### New Logic:
```python
elif isinstance(eff_args, str):
    # Try to parse as JSON first
    try:
        parsed = json.loads(eff_args)
        if isinstance(parsed, (dict, list)):
            args = json.dumps(parsed)  # Use parsed object directly
        else:
            args = json.dumps({"query": eff_args})  # Primitive value, wrap in query
    except (json.JSONDecodeError, ValueError):
        # Not valid JSON, treat as plain string
        args = json.dumps({"query": eff_args})
```

## Changes Made
- ✅ **Fixed web_search_call argument processing** (lines ~324-328)
- ✅ **Fixed function_call argument processing** (lines ~405-409)
- ✅ **Maintained backwards compatibility** for plain string arguments
- ✅ **Added proper JSON parsing** with error handling

## Testing
The fix handles multiple scenarios correctly:
- **Direct objects** (dict/list) - Serialized directly as before
- **JSON strings** - Now parsed and used directly ✅ **FIXED**
- **Plain strings** - Still wrapped in `query` field for compatibility
- **Invalid data** - Safely defaults to empty object

## Impact
This fix resolves tool call argument serialization issues for VS Code extensions and other clients that pass structured data as JSON strings, ensuring proper parameter passing without breaking existing functionality for simple string queries.