### PR TITLE
Document docker env switches for reasoning and web search

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,10 @@ VERBOSE=false
 CHATGPT_LOCAL_REASONING_EFFORT=medium       # minimal|low|medium|high
 CHATGPT_LOCAL_REASONING_SUMMARY=auto        # auto|concise|detailed|none
 CHATGPT_LOCAL_REASONING_COMPAT=think-tags   # legacy|o3|think-tags|current
+CHATGPT_LOCAL_EXPOSE_REASONING_MODELS=false
+
+# Enable default web search tool
+CHATGPT_LOCAL_ENABLE_WEB_SEARCH=false
 
 # Force a specific model name
 # CHATGPT_LOCAL_DEBUG_MODEL=gpt-5

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -27,6 +27,8 @@ Set options in `.env` or pass environment variables:
 - `CHATGPT_LOCAL_REASONING_COMPAT`: legacy|o3|think-tags|current
 - `CHATGPT_LOCAL_DEBUG_MODEL`: force model override (e.g., `gpt-5`)
 - `CHATGPT_LOCAL_CLIENT_ID`: OAuth client id override (rarely needed)
+- `CHATGPT_LOCAL_EXPOSE_REASONING_MODELS`: `true|false` to add reasoning model variants to `/v1/models`
+- `CHATGPT_LOCAL_ENABLE_WEB_SEARCH`: `true|false` to enable default web search tool
 
 ## Logs
 Set `VERBOSE=true` to include extra logging for debugging issues in upstream or chat app requests. Please include and use these logs when submitting bug reports.

--- a/chatmock/cli.py
+++ b/chatmock/cli.py
@@ -154,7 +154,7 @@ def main() -> None:
     p_serve.add_argument(
         "--expose-reasoning-models",
         action="store_true",
-        default=os.getenv("CHATGPT_LOCAL_EXPOSE_REASONING_MODELS", "").strip().lower() in ("1", "true", "yes", "on"),
+        default=(os.getenv("CHATGPT_LOCAL_EXPOSE_REASONING_MODELS") or "").strip().lower() in ("1", "true", "yes", "on"),
         help=(
             "Expose gpt-5 reasoning effort variants (minimal|low|medium|high) as separate models from /v1/models. "
             "This allows choosing effort via model selection in compatible UIs."
@@ -162,8 +162,12 @@ def main() -> None:
     )
     p_serve.add_argument(
         "--enable-web-search",
-        action="store_true",
-        help="Enable default web_search tool when a request omits responses_tools (off by default)",
+        action=argparse.BooleanOptionalAction,
+        default=(os.getenv("CHATGPT_LOCAL_ENABLE_WEB_SEARCH") or "").strip().lower() in ("1", "true", "yes", "on"),
+        help=(
+            "Enable default web_search tool when a request omits responses_tools (off by default). "
+            "Also configurable via CHATGPT_LOCAL_ENABLE_WEB_SEARCH."
+        ),
     )
 
     p_info = sub.add_parser("info", help="Print current stored tokens and derived account id")


### PR DESCRIPTION
## Summary
- allow enabling default web search via \CHATGPT_LOCAL_ENABLE_WEB_SEARCH\
- surface reasoning/web search env toggles in \.env\ template and docs

## Testing
- python -m compileall chatmock/cli.py

Closes #63