### PR TITLE
Fix/port mapping

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 # Port
 PORT=8000
 
+# Host interface used for published Docker ports (use 0.0.0.0 for remote access)
+CHATMOCK_PUBLISH_HOST=127.0.0.1
+
 # Image
 CHATMOCK_IMAGE=storagetime/chatmock:latest
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,12 @@ __pycache__/
 *$py.class
 
 # Virtual environments
-.env/
 .venv/
 venv/
+
+# Env files
+.env*
+!.env.example
 
 # Packaging artifacts
 build/

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -14,11 +14,13 @@
 3) Start the server:
    docker compose up -d chatmock
 
+   - Compose publishes the same host port as `PORT` from `.env`, so changing `PORT` changes the URL you should use.
+
 4) Free to use it in whichever chat app you like!
 
 ## Configuration
 Set options in `.env` or pass environment variables:
-- `PORT`: Container listening port (default 8000)
+- `PORT`: Container listening port and published host port for the `chatmock` service (default 8000)
 - `CHATMOCK_IMAGE`: image tag to run (default `storagetime/chatmock:latest`)
 - `VERBOSE`: `true|false` to enable request/stream logs
 - `CHATGPT_LOCAL_REASONING_EFFORT`: minimal|low|medium|high|xhigh
@@ -34,8 +36,8 @@ Set `VERBOSE=true` to include extra logging for debugging issues in upstream or 
 
 ## Test
 
-```
-curl -s http://localhost:8000/v1/chat/completions \
+```bash
+curl -s "http://localhost:${PORT:-8000}/v1/chat/completions" \
    -H 'Content-Type: application/json' \
    -d '{"model":"gpt-5-codex","messages":[{"role":"user","content":"Hello world!"}]}' | jq .
 ```

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -15,12 +15,14 @@
    docker compose up -d chatmock
 
    - Compose publishes the same host port as `PORT` from `.env`, so changing `PORT` changes the URL you should use.
+   - Published ports bind to localhost by default. Set `CHATMOCK_PUBLISH_HOST=0.0.0.0` only when the service must accept remote connections.
 
 4) Free to use it in whichever chat app you like!
 
 ## Configuration
 Set options in `.env` or pass environment variables:
 - `PORT`: Container listening port and published host port for the `chatmock` service (default 8000)
+- `CHATMOCK_PUBLISH_HOST`: Host interface used for published ports (default `127.0.0.1`; use `0.0.0.0` for remote access)
 - `CHATMOCK_IMAGE`: image tag to run (default `storagetime/chatmock:latest`)
 - `VERBOSE`: `true|false` to enable request/stream logs
 - `CHATGPT_LOCAL_REASONING_EFFORT`: minimal|low|medium|high|xhigh
@@ -37,7 +39,9 @@ Set `VERBOSE=true` to include extra logging for debugging issues in upstream or 
 ## Test
 
 ```bash
-curl -s "http://localhost:${PORT:-8000}/v1/chat/completions" \
+curl -s "http://localhost:8000/v1/chat/completions" \
    -H 'Content-Type: application/json' \
    -d '{"model":"gpt-5-codex","messages":[{"role":"user","content":"Hello world!"}]}' | jq .
 ```
+
+Replace `8000` with the `PORT` value configured in `.env` when using a custom port.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,13 +6,14 @@ services:
     env_file: .env
     environment:
       - CHATGPT_LOCAL_HOME=/data
+      - PORT=${PORT:-8000}
     ports:
-      - "8000:8000"
+      - "${PORT:-8000}:${PORT:-8000}"
     volumes:
       - chatmock_data:/data
       - ./prompt.md:/app/prompt.md:ro
     healthcheck:
-      test: ["CMD-SHELL", "python -c \"import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8000/health').status==200 else 1)\" "]
+      test: ["CMD-SHELL", "python -c \"import os,urllib.request,sys; port=os.getenv('PORT', '8000'); sys.exit(0 if urllib.request.urlopen(f'http://127.0.0.1:{port}/health').status==200 else 1)\" "]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - CHATGPT_LOCAL_HOME=/data
       - PORT=${PORT:-8000}
     ports:
-      - "${PORT:-8000}:${PORT:-8000}"
+      - "127.0.0.1:${PORT:-8000}:${PORT:-8000}"
     volumes:
       - chatmock_data:/data
       - ./prompt.md:/app/prompt.md:ro
@@ -25,11 +25,11 @@ services:
     command: ["login"]
     environment:
       - CHATGPT_LOCAL_HOME=/data
-      - CHATGPT_LOCAL_LOGIN_BIND=0.0.0.0
+      - CHATGPT_LOCAL_LOGIN_BIND=127.0.0.1
     volumes:
       - chatmock_data:/data
     ports:
-      - "1455:1455"
+      - "127.0.0.1:1455:1455"
 
 volumes:
   chatmock_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - CHATGPT_LOCAL_HOME=/data
       - PORT=${PORT:-8000}
     ports:
-      - "127.0.0.1:${PORT:-8000}:${PORT:-8000}"
+      - "${CHATMOCK_PUBLISH_HOST:-127.0.0.1}:${PORT:-8000}:${PORT:-8000}"
     volumes:
       - chatmock_data:/data
       - ./prompt.md:/app/prompt.md:ro
@@ -25,11 +25,11 @@ services:
     command: ["login"]
     environment:
       - CHATGPT_LOCAL_HOME=/data
-      - CHATGPT_LOCAL_LOGIN_BIND=127.0.0.1
+      - CHATGPT_LOCAL_LOGIN_BIND=0.0.0.0
     volumes:
       - chatmock_data:/data
     ports:
-      - "127.0.0.1:1455:1455"
+      - "${CHATMOCK_PUBLISH_HOST:-127.0.0.1}:1455:1455"
 
 volumes:
   chatmock_data:


### PR DESCRIPTION
Port mapping didn't work with docker because the environment variables were never used for port mapping or health checks. I also bound to localhost to ensure nobody exposes their instance if their network doesn't have a firewall as Docker tends to bypass firewalls at an operating system level