### PR TITLE
Add websocket upstream bridge for /v1/responses and fix VS Code payload handling

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -28,9 +28,36 @@ Set options in `.env` or pass environment variables:
 - `CHATGPT_LOCAL_CLIENT_ID`: OAuth client id override (rarely needed)
 - `CHATGPT_LOCAL_EXPOSE_REASONING_MODELS`: `true|false` to add reasoning model variants to `/v1/models`
 - `CHATGPT_LOCAL_ENABLE_WEB_SEARCH`: `true|false` to enable default web search tool
+- `CHATGPT_LOCAL_RESPONSES_WEBSOCKET_UPSTREAM`: `true|false` to opt into websocket upstream transport for HTTP `/v1/responses` (default `false`)
+
+## `/v1/responses` websocket upstream
+Set `CHATGPT_LOCAL_RESPONSES_WEBSOCKET_UPSTREAM=true` to opt into websocket upstream transport for HTTP `/v1/responses` only.
+
+- The client-facing request still uses HTTP.
+- HTTP follow-up requests still do not use `previous_response_id` in this mode.
+- ChatMock does not reuse an upstream websocket across separate HTTP requests.
+- If the websocket upstream path fails, the request fails clearly instead of silently falling back to the legacy HTTP POST upstream transport.
 
 ## Logs
 Set `VERBOSE=true` to include extra logging for troubleshooting upstream or chat app requests. Please include and use these logs when submitting bug reports.
+
+## Manual verification
+Disabled mode (`CHATGPT_LOCAL_RESPONSES_WEBSOCKET_UPSTREAM=false` or unset):
+
+```bash
+curl -s http://localhost:8000/v1/responses \
+   -H 'Content-Type: application/json' \
+   -d '{"model":"gpt-5.4","input":"Hello world!"}' | jq .
+```
+
+Confirm the default HTTP `/v1/responses` path works with the mode disabled.
+
+Enabled mode (`CHATGPT_LOCAL_RESPONSES_WEBSOCKET_UPSTREAM=true`):
+
+1. Restart `chatmock` after changing the environment variable, then rerun the same HTTP `/v1/responses` request.
+2. Confirm the request still works with the websocket bridge enabled.
+3. Send an HTTP follow-up `/v1/responses` request and confirm `previous_response_id` behaviour is unchanged.
+4. If you intentionally break websocket upstream connectivity, confirm the request fails clearly instead of silently succeeding through the legacy HTTP POST upstream path.
 
 ## Test
 

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -29,35 +29,47 @@ Set options in `.env` or pass environment variables:
 - `CHATGPT_LOCAL_EXPOSE_REASONING_MODELS`: `true|false` to add reasoning model variants to `/v1/models`
 - `CHATGPT_LOCAL_ENABLE_WEB_SEARCH`: `true|false` to enable default web search tool
 - `CHATGPT_LOCAL_RESPONSES_WEBSOCKET_UPSTREAM`: `true|false` to opt into websocket upstream transport for HTTP `/v1/responses` (default `false`)
+- `CHATGPT_LOCAL_RESPONSES_WEBSOCKET_UPSTREAM_STATEFUL`: `true|false` to retain HTTP `/v1/responses` follow-up state across requests; requires `CHATGPT_LOCAL_RESPONSES_WEBSOCKET_UPSTREAM=true` (default `false`)
 
 ## `/v1/responses` websocket upstream
 Set `CHATGPT_LOCAL_RESPONSES_WEBSOCKET_UPSTREAM=true` to opt into websocket upstream transport for HTTP `/v1/responses` only.
 
 - The client-facing request still uses HTTP.
-- HTTP follow-up requests still do not use `previous_response_id` in this mode.
-- ChatMock does not reuse an upstream websocket across separate HTTP requests.
+- With only `CHATGPT_LOCAL_RESPONSES_WEBSOCKET_UPSTREAM=true`, HTTP follow-up requests stay one-shot. ChatMock does not reuse an upstream websocket across separate HTTP requests and does not automatically reuse `previous_response_id`.
+- Set `CHATGPT_LOCAL_RESPONSES_WEBSOCKET_UPSTREAM_STATEFUL=true` as well to enable the stateful bridge mode. This mode requires websocket-upstream mode; it is not valid on its own.
+- Stateful HTTP requests must include a non-empty `X-Session-Id` or `session_id` header. Reuse is keyed by that explicit session id.
+- In stateful mode, streaming HTTP `/v1/responses` are buffered inside ChatMock until the upstream response completes, then returned as SSE. Clients do not receive incremental SSE delivery in that mode.
+- Retained websocket ownership is process-local only. There is no shared registry across workers, containers, or processes, so follow-up requests must keep hitting the same ChatMock process.
 - If the websocket upstream path fails, the request fails clearly instead of silently falling back to the legacy HTTP POST upstream transport.
+- Rollback is immediate: set `CHATGPT_LOCAL_RESPONSES_WEBSOCKET_UPSTREAM_STATEFUL=false` or unset it, and ChatMock returns to the existing one-shot bridge behavior.
 
 ## Logs
 Set `VERBOSE=true` to include extra logging for troubleshooting upstream or chat app requests. Please include and use these logs when submitting bug reports.
 
 ## Manual verification
-Disabled mode (`CHATGPT_LOCAL_RESPONSES_WEBSOCKET_UPSTREAM=false` or unset):
+Default-off regression check (`CHATGPT_LOCAL_RESPONSES_WEBSOCKET_UPSTREAM=true` and `CHATGPT_LOCAL_RESPONSES_WEBSOCKET_UPSTREAM_STATEFUL=false` or unset):
 
 ```bash
 curl -s http://localhost:8000/v1/responses \
    -H 'Content-Type: application/json' \
-   -d '{"model":"gpt-5.4","input":"Hello world!"}' | jq .
+   -H 'X-Session-Id: docs-regression' \
+   -d '{"model":"gpt-5.4","input":"Remember the token ALPHA-42."}' | jq .
+
+curl -s http://localhost:8000/v1/responses \
+   -H 'Content-Type: application/json' \
+   -H 'X-Session-Id: docs-regression' \
+   -d '{"model":"gpt-5.4","input":"What token did I ask you to remember?"}' | jq .
 ```
 
-Confirm the default HTTP `/v1/responses` path works with the mode disabled.
+Confirm the second response behaves like a fresh one-shot request rather than continuing the first turn.
 
-Enabled mode (`CHATGPT_LOCAL_RESPONSES_WEBSOCKET_UPSTREAM=true`):
+Stateful mode (`CHATGPT_LOCAL_RESPONSES_WEBSOCKET_UPSTREAM=true` and `CHATGPT_LOCAL_RESPONSES_WEBSOCKET_UPSTREAM_STATEFUL=true`):
 
 1. Restart `chatmock` after changing the environment variable, then rerun the same HTTP `/v1/responses` request.
-2. Confirm the request still works with the websocket bridge enabled.
-3. Send an HTTP follow-up `/v1/responses` request and confirm `previous_response_id` behaviour is unchanged.
-4. If you intentionally break websocket upstream connectivity, confirm the request fails clearly instead of silently succeeding through the legacy HTTP POST upstream path.
+2. Send both requests with the same non-empty `X-Session-Id` or `session_id` header.
+3. Confirm the second response continues the conversation and can answer with `ALPHA-42`.
+4. Keep both requests on the same ChatMock process; cross-worker or shared-registry follow-up reuse is not supported.
+5. If you intentionally break websocket upstream connectivity, confirm the request fails clearly instead of silently succeeding through the legacy HTTP POST upstream path.
 
 ## Test
 

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -37,8 +37,11 @@ Set `CHATGPT_LOCAL_RESPONSES_WEBSOCKET_UPSTREAM=true` to opt into websocket upst
 - The client-facing request still uses HTTP.
 - With only `CHATGPT_LOCAL_RESPONSES_WEBSOCKET_UPSTREAM=true`, HTTP follow-up requests stay one-shot. ChatMock does not reuse an upstream websocket across separate HTTP requests and does not automatically reuse `previous_response_id`.
 - Set `CHATGPT_LOCAL_RESPONSES_WEBSOCKET_UPSTREAM_STATEFUL=true` as well to enable the stateful bridge mode. This mode requires websocket-upstream mode; it is not valid on its own.
-- Stateful HTTP requests must include a non-empty `X-Session-Id` or `session_id` header. Reuse is keyed by that explicit session id.
-- In stateful mode, streaming HTTP `/v1/responses` are buffered inside ChatMock until the upstream response completes, then returned as SSE. Clients do not receive incremental SSE delivery in that mode.
+- In stateful mode, the first HTTP turn starts a new conversation. It does not require `previous_response_id`, and blank explicit `X-Session-Id` or `session_id` headers do not block that first-turn request.
+- Stateful follow-up turns continue by sending `previous_response_id`. ChatMock retains websocket ownership by response marker rather than by explicit session header.
+- Repeating the same follow-up marker is a deterministic conflict that returns HTTP `409`.
+- For non-streaming stateful HTTP requests, a stale marker or lost retained socket returns HTTP `400` with `error.code=previous_response_not_found`. Clients such as VS Code can retry without `previous_response_id`.
+- In stateful mode, streaming HTTP `/v1/responses` are buffered inside ChatMock until the upstream response completes, then returned as SSE. Invalid-marker parity is not provided in this change: the current behavior is HTTP `200` plus an SSE-embedded error characterization, not a pre-commit HTTP `400`.
 - Retained websocket ownership is process-local only. There is no shared registry across workers, containers, or processes, so follow-up requests must keep hitting the same ChatMock process.
 - If the websocket upstream path fails, the request fails clearly instead of silently falling back to the legacy HTTP POST upstream transport.
 - Rollback is immediate: set `CHATGPT_LOCAL_RESPONSES_WEBSOCKET_UPSTREAM_STATEFUL=false` or unset it, and ChatMock returns to the existing one-shot bridge behavior.
@@ -65,11 +68,13 @@ Confirm the second response behaves like a fresh one-shot request rather than co
 
 Stateful mode (`CHATGPT_LOCAL_RESPONSES_WEBSOCKET_UPSTREAM=true` and `CHATGPT_LOCAL_RESPONSES_WEBSOCKET_UPSTREAM_STATEFUL=true`):
 
-1. Restart `chatmock` after changing the environment variable, then rerun the same HTTP `/v1/responses` request.
-2. Send both requests with the same non-empty `X-Session-Id` or `session_id` header.
-3. Confirm the second response continues the conversation and can answer with `ALPHA-42`.
-4. Keep both requests on the same ChatMock process; cross-worker or shared-registry follow-up reuse is not supported.
-5. If you intentionally break websocket upstream connectivity, confirm the request fails clearly instead of silently succeeding through the legacy HTTP POST upstream path.
+1. Restart `chatmock` after changing the environment variable, then send a first HTTP `/v1/responses` request without `previous_response_id`. Optionally send a blank `X-Session-Id` or `session_id` header and confirm it does not block the request.
+2. Send a second request with `previous_response_id` from the first turn and confirm the conversation continues and can answer with `ALPHA-42`.
+3. Repeat the same follow-up request for that marker and confirm the conflict is deterministic and returns HTTP `409`.
+4. For a non-streaming follow-up, force a stale marker or lost retained socket and confirm HTTP `400` with `error.code=previous_response_not_found`, so the client can retry without `previous_response_id`.
+5. For a streaming follow-up with an invalid marker, confirm the current limitation: HTTP `200` with an SSE-embedded error characterization, not a pre-commit HTTP `400`.
+6. Keep the follow-up requests on the same ChatMock process; cross-worker or shared-registry follow-up reuse is not supported.
+7. If you intentionally break websocket upstream connectivity, confirm the request fails clearly instead of silently succeeding through the legacy HTTP POST upstream path.
 
 ## Test
 

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -41,7 +41,7 @@ Set `CHATGPT_LOCAL_RESPONSES_WEBSOCKET_UPSTREAM=true` to opt into websocket upst
 - Stateful follow-up turns continue by sending `previous_response_id`. ChatMock retains websocket ownership by response marker rather than by explicit session header.
 - Repeating the same follow-up marker is a deterministic conflict that returns HTTP `409`.
 - For non-streaming stateful HTTP requests, a stale marker or lost retained socket returns HTTP `400` with `error.code=previous_response_not_found`. Clients such as VS Code can retry without `previous_response_id`.
-- In stateful mode, streaming HTTP `/v1/responses` are buffered inside ChatMock until the upstream response completes, then returned as SSE. Invalid-marker parity is not provided in this change: the current behavior is HTTP `200` plus an SSE-embedded error characterization, not a pre-commit HTTP `400`.
+- In stateful mode, streaming HTTP `/v1/responses` now stay incremental: ChatMock passes through SSE events as the upstream websocket produces them while still finalizing retained websocket ownership when the stream completes, fails, or is aborted. Invalid-marker parity is not provided in this change: the current behavior is HTTP `200` plus an SSE-embedded error characterization, not a pre-commit HTTP `400`.
 - Retained websocket ownership is process-local only. There is no shared registry across workers, containers, or processes, so follow-up requests must keep hitting the same ChatMock process.
 - If the websocket upstream path fails, the request fails clearly instead of silently falling back to the legacy HTTP POST upstream transport.
 - Rollback is immediate: set `CHATGPT_LOCAL_RESPONSES_WEBSOCKET_UPSTREAM_STATEFUL=false` or unset it, and ChatMock returns to the existing one-shot bridge behavior.

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ All flags go after `chatmock serve`. These can also be set as environment variab
 | `--fast-mode` | `CHATGPT_LOCAL_FAST_MODE` | true/false | false | Priority processing for supported models |
 | `--enable-web-search` | `CHATGPT_LOCAL_ENABLE_WEB_SEARCH` | true/false | false | Allow the model to search the web |
 | `--expose-reasoning-models` | `CHATGPT_LOCAL_EXPOSE_REASONING_MODELS` | true/false | false | List each reasoning level as its own model |
+| `--responses-websocket-upstream` / `--no-responses-websocket-upstream` | `CHATGPT_LOCAL_RESPONSES_WEBSOCKET_UPSTREAM` | true/false | false | Use websocket upstream transport for HTTP `/v1/responses` only |
 
 <details>
 <summary><b>Web search in a request</b></summary>
@@ -161,6 +162,23 @@ All flags go after `chatmock serve`. These can also be set as environment variab
   "fast_mode": true
 }
 ```
+
+</details>
+
+<details>
+<summary><b>HTTP /v1/responses websocket upstream</b></summary>
+
+- Disabled by default.
+- This only changes the upstream transport for HTTP `/v1/responses` requests.
+- HTTP follow-up requests still do not use `previous_response_id` in this mode.
+- ChatMock does not reuse an upstream websocket across separate HTTP requests.
+- If the websocket upstream path fails, the request fails clearly instead of silently falling back to the legacy HTTP POST upstream transport.
+
+Manual verification:
+1. Start `chatmock serve` (or `chatmock serve --no-responses-websocket-upstream`) and confirm a basic HTTP `/v1/responses` request works with the default disabled mode.
+2. Restart with `chatmock serve --responses-websocket-upstream` and confirm the same HTTP `/v1/responses` request still works with the bridge enabled.
+3. In enabled mode, send an HTTP follow-up `/v1/responses` request and confirm `previous_response_id` behaviour is unchanged.
+4. In enabled mode, if you intentionally break websocket upstream connectivity, confirm the request fails clearly instead of silently succeeding through the legacy HTTP POST upstream path.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ All flags go after `chatmock serve`. These can also be set as environment variab
 - Stateful follow-up turns continue by sending `previous_response_id`. ChatMock retains websocket ownership by response marker rather than by explicit session header.
 - Repeating the same follow-up marker is a deterministic conflict that returns HTTP `409`.
 - For non-streaming stateful HTTP requests, a stale marker or lost retained socket returns HTTP `400` with `error.code=previous_response_not_found`. Clients such as VS Code can retry without `previous_response_id`.
-- In stateful mode, streaming HTTP `/v1/responses` are buffered inside ChatMock until the upstream response completes, then returned as SSE. Invalid-marker parity is not provided in this change: the current behavior is HTTP `200` plus an SSE-embedded error characterization, not a pre-commit HTTP `400`.
+- In stateful mode, streaming HTTP `/v1/responses` now stay incremental: ChatMock passes through SSE events as the upstream websocket produces them while still finalizing retained websocket ownership when the stream completes, fails, or is aborted. Invalid-marker parity is not provided in this change: the current behavior is HTTP `200` plus an SSE-embedded error characterization, not a pre-commit HTTP `400`.
 - Stateful retained websocket ownership is process-local only. There is no cross-worker, cross-process, or shared-registry guarantee, so follow-up requests must reach the same ChatMock process.
 - If the websocket upstream path fails, the request fails clearly instead of silently falling back to the legacy HTTP POST upstream transport.
 - Rollback is a config change only: disable `--responses-websocket-upstream-stateful` and ChatMock returns to the existing one-shot websocket-bridge behavior.

--- a/README.md
+++ b/README.md
@@ -173,17 +173,24 @@ All flags go after `chatmock serve`. These can also be set as environment variab
 - `--responses-websocket-upstream` enables a transport-only bridge for HTTP `/v1/responses`. The client still uses HTTP, but ChatMock sends the upstream request over websocket.
 - In transport-only mode, HTTP follow-up requests stay one-shot: ChatMock does not reuse an upstream websocket across requests and still does not reuse `previous_response_id` automatically.
 - `--responses-websocket-upstream-stateful` adds retained follow-up state on top of websocket-upstream mode. It requires `--responses-websocket-upstream` and startup fails if websocket-upstream mode is not also enabled.
-- In stateful mode, every stateful HTTP request must include a non-empty `X-Session-Id` or `session_id` header. Reuse is keyed by that explicit session id.
-- In stateful mode, streaming HTTP `/v1/responses` are buffered inside ChatMock until the upstream response completes, then returned as SSE. Clients do not receive incremental SSE delivery in that mode.
+- In stateful mode, the first HTTP turn starts a new conversation. It does not require `previous_response_id`, and blank explicit `X-Session-Id` or `session_id` headers do not block that first-turn request.
+- Stateful follow-up turns continue by sending `previous_response_id`. ChatMock retains websocket ownership by response marker rather than by explicit session header.
+- Repeating the same follow-up marker is a deterministic conflict that returns HTTP `409`.
+- For non-streaming stateful HTTP requests, a stale marker or lost retained socket returns HTTP `400` with `error.code=previous_response_not_found`. Clients such as VS Code can retry without `previous_response_id`.
+- In stateful mode, streaming HTTP `/v1/responses` are buffered inside ChatMock until the upstream response completes, then returned as SSE. Invalid-marker parity is not provided in this change: the current behavior is HTTP `200` plus an SSE-embedded error characterization, not a pre-commit HTTP `400`.
 - Stateful retained websocket ownership is process-local only. There is no cross-worker, cross-process, or shared-registry guarantee, so follow-up requests must reach the same ChatMock process.
 - If the websocket upstream path fails, the request fails clearly instead of silently falling back to the legacy HTTP POST upstream transport.
 - Rollback is a config change only: disable `--responses-websocket-upstream-stateful` and ChatMock returns to the existing one-shot websocket-bridge behavior.
 
 Manual verification:
-1. Default-off regression: start `chatmock serve --responses-websocket-upstream` without `--responses-websocket-upstream-stateful`, then send two HTTP `/v1/responses` requests with the same `X-Session-Id`. Example prompts: first `Remember the token ALPHA-42.`, then `What token did I ask you to remember?`. Confirm the second request behaves like a fresh one-shot request rather than a retained follow-up.
-2. Stateful mode: restart with both `--responses-websocket-upstream` and `--responses-websocket-upstream-stateful`, then send the same two HTTP `/v1/responses` requests with the same non-empty `X-Session-Id` (or `session_id`) header. Confirm the second request continues the conversation and can answer with `ALPHA-42`.
-3. For the stateful check, send the follow-up to the same ChatMock process. Multi-worker or shared-registry behavior is not provided.
-4. In either websocket-upstream mode, if you intentionally break websocket upstream connectivity, confirm the request fails clearly instead of silently succeeding through the legacy HTTP POST upstream path.
+1. Default-off regression: start `chatmock serve --responses-websocket-upstream` without `--responses-websocket-upstream-stateful`, then send two HTTP `/v1/responses` requests with the same optional `X-Session-Id`. Example prompts: first `Remember the token ALPHA-42.`, then `What token did I ask you to remember?`. Confirm the second request behaves like a fresh one-shot request rather than a retained follow-up.
+2. Stateful mode: restart with both `--responses-websocket-upstream` and `--responses-websocket-upstream-stateful`, then send a first HTTP `/v1/responses` request without `previous_response_id`. Optionally send a blank `X-Session-Id` or `session_id` header and confirm it does not block the request.
+3. Send a second request with `previous_response_id` from the first turn and confirm the conversation continues and can answer with `ALPHA-42`.
+4. Repeat the same follow-up request for that marker and confirm the conflict is deterministic and returns HTTP `409`.
+5. For a non-streaming follow-up, force a stale marker or lost retained socket and confirm HTTP `400` with `error.code=previous_response_not_found`, so the client can retry without `previous_response_id`.
+6. For a streaming follow-up with an invalid marker, confirm the current limitation: HTTP `200` with an SSE-embedded error characterization, not a pre-commit HTTP `400`.
+7. For the stateful checks, send the follow-up to the same ChatMock process. Multi-worker or shared-registry behavior is not provided.
+8. In either websocket-upstream mode, if you intentionally break websocket upstream connectivity, confirm the request fails clearly instead of silently succeeding through the legacy HTTP POST upstream path.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ All flags go after `chatmock serve`. These can also be set as environment variab
 | `--enable-web-search` | `CHATGPT_LOCAL_ENABLE_WEB_SEARCH` | true/false | false | Allow the model to search the web |
 | `--expose-reasoning-models` | `CHATGPT_LOCAL_EXPOSE_REASONING_MODELS` | true/false | false | List each reasoning level as its own model |
 | `--responses-websocket-upstream` / `--no-responses-websocket-upstream` | `CHATGPT_LOCAL_RESPONSES_WEBSOCKET_UPSTREAM` | true/false | false | Use websocket upstream transport for HTTP `/v1/responses` only |
+| `--responses-websocket-upstream-stateful` / `--no-responses-websocket-upstream-stateful` | `CHATGPT_LOCAL_RESPONSES_WEBSOCKET_UPSTREAM_STATEFUL` | true/false | false | Retain HTTP `/v1/responses` follow-up state across requests; requires websocket upstream mode |
 
 <details>
 <summary><b>Web search in a request</b></summary>
@@ -166,19 +167,23 @@ All flags go after `chatmock serve`. These can also be set as environment variab
 </details>
 
 <details>
-<summary><b>HTTP /v1/responses websocket upstream</b></summary>
+<summary><b>HTTP /v1/responses websocket upstream modes</b></summary>
 
 - Disabled by default.
-- This only changes the upstream transport for HTTP `/v1/responses` requests.
-- HTTP follow-up requests still do not use `previous_response_id` in this mode.
-- ChatMock does not reuse an upstream websocket across separate HTTP requests.
+- `--responses-websocket-upstream` enables a transport-only bridge for HTTP `/v1/responses`. The client still uses HTTP, but ChatMock sends the upstream request over websocket.
+- In transport-only mode, HTTP follow-up requests stay one-shot: ChatMock does not reuse an upstream websocket across requests and still does not reuse `previous_response_id` automatically.
+- `--responses-websocket-upstream-stateful` adds retained follow-up state on top of websocket-upstream mode. It requires `--responses-websocket-upstream` and startup fails if websocket-upstream mode is not also enabled.
+- In stateful mode, every stateful HTTP request must include a non-empty `X-Session-Id` or `session_id` header. Reuse is keyed by that explicit session id.
+- In stateful mode, streaming HTTP `/v1/responses` are buffered inside ChatMock until the upstream response completes, then returned as SSE. Clients do not receive incremental SSE delivery in that mode.
+- Stateful retained websocket ownership is process-local only. There is no cross-worker, cross-process, or shared-registry guarantee, so follow-up requests must reach the same ChatMock process.
 - If the websocket upstream path fails, the request fails clearly instead of silently falling back to the legacy HTTP POST upstream transport.
+- Rollback is a config change only: disable `--responses-websocket-upstream-stateful` and ChatMock returns to the existing one-shot websocket-bridge behavior.
 
 Manual verification:
-1. Start `chatmock serve` (or `chatmock serve --no-responses-websocket-upstream`) and confirm a basic HTTP `/v1/responses` request works with the default disabled mode.
-2. Restart with `chatmock serve --responses-websocket-upstream` and confirm the same HTTP `/v1/responses` request still works with the bridge enabled.
-3. In enabled mode, send an HTTP follow-up `/v1/responses` request and confirm `previous_response_id` behaviour is unchanged.
-4. In enabled mode, if you intentionally break websocket upstream connectivity, confirm the request fails clearly instead of silently succeeding through the legacy HTTP POST upstream path.
+1. Default-off regression: start `chatmock serve --responses-websocket-upstream` without `--responses-websocket-upstream-stateful`, then send two HTTP `/v1/responses` requests with the same `X-Session-Id`. Example prompts: first `Remember the token ALPHA-42.`, then `What token did I ask you to remember?`. Confirm the second request behaves like a fresh one-shot request rather than a retained follow-up.
+2. Stateful mode: restart with both `--responses-websocket-upstream` and `--responses-websocket-upstream-stateful`, then send the same two HTTP `/v1/responses` requests with the same non-empty `X-Session-Id` (or `session_id`) header. Confirm the second request continues the conversation and can answer with `ALPHA-42`.
+3. For the stateful check, send the follow-up to the same ChatMock process. Multi-worker or shared-registry behavior is not provided.
+4. In either websocket-upstream mode, if you intentionally break websocket upstream connectivity, confirm the request fails clearly instead of silently succeeding through the legacy HTTP POST upstream path.
 
 </details>
 

--- a/chatmock/app.py
+++ b/chatmock/app.py
@@ -20,6 +20,7 @@ def create_app(
     debug_model: str | None = None,
     expose_reasoning_models: bool = False,
     default_web_search: bool = False,
+    responses_websocket_upstream: bool = False,
 ) -> Flask:
     app = Flask(__name__)
 
@@ -35,6 +36,7 @@ def create_app(
         GPT5_CODEX_INSTRUCTIONS=GPT5_CODEX_INSTRUCTIONS,
         EXPOSE_REASONING_MODELS=bool(expose_reasoning_models),
         DEFAULT_WEB_SEARCH=bool(default_web_search),
+        RESPONSES_WEBSOCKET_UPSTREAM=bool(responses_websocket_upstream),
     )
 
     @app.get("/")

--- a/chatmock/app.py
+++ b/chatmock/app.py
@@ -21,7 +21,13 @@ def create_app(
     expose_reasoning_models: bool = False,
     default_web_search: bool = False,
     responses_websocket_upstream: bool = False,
+    responses_websocket_upstream_stateful: bool = False,
 ) -> Flask:
+    if bool(responses_websocket_upstream_stateful) and not bool(responses_websocket_upstream):
+        raise ValueError(
+            "RESPONSES_WEBSOCKET_UPSTREAM_STATEFUL requires RESPONSES_WEBSOCKET_UPSTREAM"
+        )
+
     app = Flask(__name__)
 
     app.config.update(
@@ -37,6 +43,7 @@ def create_app(
         EXPOSE_REASONING_MODELS=bool(expose_reasoning_models),
         DEFAULT_WEB_SEARCH=bool(default_web_search),
         RESPONSES_WEBSOCKET_UPSTREAM=bool(responses_websocket_upstream),
+        RESPONSES_WEBSOCKET_UPSTREAM_STATEFUL=bool(responses_websocket_upstream_stateful),
     )
 
     @app.get("/")

--- a/chatmock/cli.py
+++ b/chatmock/cli.py
@@ -272,6 +272,7 @@ def cmd_serve(
     expose_reasoning_models: bool,
     default_web_search: bool,
     responses_websocket_upstream: bool,
+    responses_websocket_upstream_stateful: bool,
 ) -> int:
     app = create_app(
         verbose=verbose,
@@ -284,6 +285,7 @@ def cmd_serve(
         expose_reasoning_models=expose_reasoning_models,
         default_web_search=default_web_search,
         responses_websocket_upstream=responses_websocket_upstream,
+        responses_websocket_upstream_stateful=responses_websocket_upstream_stateful,
     )
 
     app.run(host=host, use_reloader=False, port=port, threaded=True)
@@ -367,6 +369,17 @@ def main() -> None:
             "Also configurable via CHATGPT_LOCAL_RESPONSES_WEBSOCKET_UPSTREAM."
         ),
     )
+    p_serve.add_argument(
+        "--responses-websocket-upstream-stateful",
+        action=argparse.BooleanOptionalAction,
+        default=(os.getenv("CHATGPT_LOCAL_RESPONSES_WEBSOCKET_UPSTREAM_STATEFUL") or "").strip().lower()
+        in ("1", "true", "yes", "on"),
+        help=(
+            "Retain HTTP websocket-bridge follow-up state across requests (off by default). "
+            "Requires --responses-websocket-upstream. Also configurable via "
+            "CHATGPT_LOCAL_RESPONSES_WEBSOCKET_UPSTREAM_STATEFUL."
+        ),
+    )
 
     p_info = sub.add_parser("info", help="Print current stored tokens and derived account id")
     p_info.add_argument("--json", action="store_true", help="Output raw auth.json contents")
@@ -390,6 +403,7 @@ def main() -> None:
                 expose_reasoning_models=args.expose_reasoning_models,
                 default_web_search=args.enable_web_search,
                 responses_websocket_upstream=args.responses_websocket_upstream,
+                responses_websocket_upstream_stateful=args.responses_websocket_upstream_stateful,
             )
         )
     elif args.command == "info":

--- a/chatmock/cli.py
+++ b/chatmock/cli.py
@@ -271,6 +271,7 @@ def cmd_serve(
     debug_model: str | None,
     expose_reasoning_models: bool,
     default_web_search: bool,
+    responses_websocket_upstream: bool,
 ) -> int:
     app = create_app(
         verbose=verbose,
@@ -282,6 +283,7 @@ def cmd_serve(
         debug_model=debug_model,
         expose_reasoning_models=expose_reasoning_models,
         default_web_search=default_web_search,
+        responses_websocket_upstream=responses_websocket_upstream,
     )
 
     app.run(host=host, use_reloader=False, port=port, threaded=True)
@@ -356,6 +358,15 @@ def main() -> None:
             "Also configurable via CHATGPT_LOCAL_ENABLE_WEB_SEARCH."
         ),
     )
+    p_serve.add_argument(
+        "--responses-websocket-upstream",
+        action=argparse.BooleanOptionalAction,
+        default=(os.getenv("CHATGPT_LOCAL_RESPONSES_WEBSOCKET_UPSTREAM") or "").strip().lower() in ("1", "true", "yes", "on"),
+        help=(
+            "Use an upstream WebSocket transport for Responses API requests (off by default). "
+            "Also configurable via CHATGPT_LOCAL_RESPONSES_WEBSOCKET_UPSTREAM."
+        ),
+    )
 
     p_info = sub.add_parser("info", help="Print current stored tokens and derived account id")
     p_info.add_argument("--json", action="store_true", help="Output raw auth.json contents")
@@ -378,6 +389,7 @@ def main() -> None:
                 debug_model=args.debug_model,
                 expose_reasoning_models=args.expose_reasoning_models,
                 default_web_search=args.enable_web_search,
+                responses_websocket_upstream=args.responses_websocket_upstream,
             )
         )
     elif args.command == "info":

--- a/chatmock/responses_api.py
+++ b/chatmock/responses_api.py
@@ -89,12 +89,12 @@ def normalize_responses_payload(
     normalized = dict(payload)
     normalized["model"] = normalized_model
     normalized.pop("max_output_tokens", None)
+    normalized.pop("truncation", None)
 
     if "input" in normalized:
         normalized["input"] = canonicalize_responses_input(normalized.get("input"))
 
-    if "store" not in normalized:
-        normalized["store"] = False
+    normalized["store"] = False
 
     instructions = normalized.get("instructions")
     if not isinstance(instructions, str) or not instructions.strip():

--- a/chatmock/responses_api.py
+++ b/chatmock/responses_api.py
@@ -183,6 +183,7 @@ def aggregate_response_from_sse(
 ) -> tuple[Dict[str, Any] | None, Dict[str, Any] | None]:
     response_obj: Dict[str, Any] | None = None
     error_obj: Dict[str, Any] | None = None
+    completed_output_items: list[Dict[str, Any]] = []
     try:
         for evt in iter_sse_event_payloads(upstream):
             if callable(on_event):
@@ -194,6 +195,10 @@ def aggregate_response_from_sse(
             if isinstance(response, dict):
                 response_obj = response
             kind = evt.get("type")
+            if kind == "response.output_item.done":
+                item = evt.get("item")
+                if isinstance(item, dict):
+                    completed_output_items.append(item)
             if kind == "response.failed":
                 if isinstance(response, dict) and isinstance(response.get("error"), dict):
                     error_obj = {"error": response.get("error")}
@@ -201,6 +206,10 @@ def aggregate_response_from_sse(
                     error_obj = {"error": {"message": "response.failed"}}
                 break
             if kind == "response.completed":
+                if isinstance(response_obj, dict):
+                    output = response_obj.get("output")
+                    if (not isinstance(output, list) or not output) and completed_output_items:
+                        response_obj = {**response_obj, "output": completed_output_items}
                 break
     finally:
         upstream.close()

--- a/chatmock/responses_websocket_bridge.py
+++ b/chatmock/responses_websocket_bridge.py
@@ -57,6 +57,18 @@ def _json_response(body: Dict[str, Any], *, status_code: int) -> Response:
     return _with_cors(make_response(jsonify(body), status_code))
 
 
+def _previous_response_not_found_error(response_marker: str | None) -> Dict[str, Any]:
+    message = "No response found for previous_response_id."
+    if response_marker:
+        message = f"No response found for previous_response_id {response_marker}."
+    return {
+        "error": {
+            "message": message,
+            "code": "previous_response_not_found",
+        }
+    }
+
+
 def _sse_response(payload_iter) -> Response:
     response = Response(
         payload_iter,
@@ -69,6 +81,10 @@ def _sse_response(payload_iter) -> Response:
 
 def _terminal_event(event: Dict[str, Any]) -> bool:
     return event.get("type") in ("response.completed", "response.failed", "error")
+
+
+def _has_previous_response_not_found_code(error: Dict[str, Any] | None) -> bool:
+    return isinstance(error, dict) and error.get("code") == "previous_response_not_found"
 
 
 def parse_upstream_websocket_event(message: Any) -> Dict[str, Any]:
@@ -223,6 +239,7 @@ def _collect_response(
     session_id: str,
     verbose: bool,
     retained_lease: RetainedUpstreamWebsocketLease | None = None,
+    response_marker: str | None = None,
 ) -> tuple[Dict[str, Any] | None, Dict[str, Any] | None, int]:
     response_obj: Dict[str, Any] | None = None
     completed_output_items: list[Dict[str, Any]] = []
@@ -253,11 +270,15 @@ def _collect_response(
                 clear_responses_reuse_state(session_id)
                 retain_upstream = False
                 error = response.get("error") if isinstance(response.get("error"), dict) else {"message": "response.failed"}
+                if response_marker and _has_previous_response_not_found_code(error):
+                    return None, _previous_response_not_found_error(response_marker), 400
                 return None, {"error": error}, 502
             if event_type == "error":
                 clear_responses_reuse_state(session_id)
                 retain_upstream = False
                 error = event.get("error") if isinstance(event.get("error"), dict) else {"message": "Upstream websocket error"}
+                if response_marker and _has_previous_response_not_found_code(error):
+                    return None, _previous_response_not_found_error(response_marker), 400
                 status_code = event.get("status_code") if isinstance(event.get("status_code"), int) else 502
                 return None, {"error": error}, status_code
             if event_type == "response.completed":
@@ -269,6 +290,8 @@ def _collect_response(
     except ResponsesWebsocketBridgeProtocolError as exc:
         clear_responses_reuse_state(session_id)
         retain_upstream = False
+        if response_marker:
+            return None, _previous_response_not_found_error(response_marker), 400
         return None, {"error": {"message": str(exc)}}, 502
     finally:
         _release_upstream_websocket(
@@ -332,15 +355,7 @@ def send_responses_request_via_websocket(
         else:
             upstream_ws = _connect_upstream_websocket()
     except ResponsesWebsocketSessionNotFoundError:
-        return _json_response(
-            {
-                "error": {
-                    "message": f"No response found for previous_response_id {response_marker}.",
-                    "code": "previous_response_not_found",
-                }
-            },
-            status_code=400,
-        )
+        return _json_response(_previous_response_not_found_error(response_marker), status_code=400)
     except ResponsesWebsocketSessionConflictError as exc:
         return _json_response(
             {"error": {"message": str(exc)}},
@@ -380,6 +395,11 @@ def send_responses_request_via_websocket(
             retained_lease=retained_lease,
             retain=False,
         )
+        if response_marker:
+            return _json_response(
+                _previous_response_not_found_error(response_marker),
+                status_code=400,
+            )
         return _json_response(
             {"error": {"message": f"Upstream websocket request send failed: {exc}"}},
             status_code=502,
@@ -401,6 +421,7 @@ def send_responses_request_via_websocket(
         session_id=session_id,
         verbose=verbose,
         retained_lease=retained_lease,
+        response_marker=response_marker,
     )
     if error_obj is not None:
         return _json_response(error_obj, status_code=status_code)

--- a/chatmock/responses_websocket_bridge.py
+++ b/chatmock/responses_websocket_bridge.py
@@ -1,8 +1,183 @@
 from __future__ import annotations
 
+import json
 from typing import Any, Dict
 
-from flask import Response
+from flask import Response, jsonify, make_response
+from websockets.exceptions import ConnectionClosed
+
+from .http import build_cors_headers
+from .session import (
+    clear_responses_reuse_state,
+    note_responses_final_response,
+    note_responses_stream_event,
+)
+from .upstream import build_upstream_headers, build_upstream_websocket_url, connect_upstream_websocket
+from .utils import get_effective_chatgpt_auth
+
+
+class ResponsesWebsocketBridgeProtocolError(ValueError):
+    pass
+
+
+def _log_json(prefix: str, payload: Any) -> None:
+    try:
+        print(f"{prefix}\n{json.dumps(payload, indent=2, ensure_ascii=False)}")
+    except Exception:
+        try:
+            print(f"{prefix}\n{payload}")
+        except Exception:
+            pass
+
+
+def _with_cors(response: Response) -> Response:
+    for key, value in build_cors_headers().items():
+        response.headers.setdefault(key, value)
+    return response
+
+
+def _json_response(body: Dict[str, Any], *, status_code: int) -> Response:
+    return _with_cors(make_response(jsonify(body), status_code))
+
+
+def _sse_response(payload_iter) -> Response:
+    response = Response(
+        payload_iter,
+        status=200,
+        mimetype="text/event-stream",
+        headers={"Cache-Control": "no-cache", "Connection": "keep-alive"},
+    )
+    return _with_cors(response)
+
+
+def _terminal_event(event: Dict[str, Any]) -> bool:
+    return event.get("type") in ("response.completed", "response.failed", "error")
+
+
+def parse_upstream_websocket_event(message: Any) -> Dict[str, Any]:
+    if isinstance(message, bytes):
+        raw_text = message.decode("utf-8", errors="ignore")
+    else:
+        raw_text = str(message)
+
+    try:
+        payload = json.loads(raw_text)
+    except Exception as exc:
+        raise ResponsesWebsocketBridgeProtocolError(
+            "Upstream websocket event payload was not a JSON object"
+        ) from exc
+
+    if not isinstance(payload, dict):
+        raise ResponsesWebsocketBridgeProtocolError(
+            "Upstream websocket event payload was not a JSON object"
+        )
+
+    event_type = payload.get("type")
+    if not isinstance(event_type, str) or not event_type.strip():
+        raise ResponsesWebsocketBridgeProtocolError(
+            "Upstream websocket event payload is missing a string type"
+        )
+
+    if event_type in ("response.completed", "response.failed") and not isinstance(payload.get("response"), dict):
+        raise ResponsesWebsocketBridgeProtocolError(
+            f"Upstream websocket {event_type} event is missing a response object"
+        )
+
+    return payload
+
+
+def _recv_upstream_event(upstream_ws) -> Dict[str, Any]:
+    try:
+        message = upstream_ws.recv()
+    except ConnectionClosed as exc:
+        raise ResponsesWebsocketBridgeProtocolError(
+            "Upstream websocket closed before response.completed"
+        ) from exc
+
+    if message is None:
+        raise ResponsesWebsocketBridgeProtocolError(
+            "Upstream websocket closed before response.completed"
+        )
+
+    return parse_upstream_websocket_event(message)
+
+
+def _encode_sse_event(event: Dict[str, Any]) -> bytes:
+    payload = json.dumps(event, separators=(",", ":"), ensure_ascii=False)
+    return ("data: " + payload + "\n\n").encode("utf-8")
+
+
+def _send_upstream_request(upstream_ws, payload: Dict[str, Any], *, verbose: bool) -> None:
+    if verbose:
+        _log_json("OUTBOUND >> ChatGPT Responses WS payload", payload)
+    upstream_ws.send(json.dumps(payload))
+
+
+def _iter_streaming_events(upstream_ws, *, session_id: str, verbose: bool):
+    try:
+        while True:
+            try:
+                event = _recv_upstream_event(upstream_ws)
+            except ResponsesWebsocketBridgeProtocolError as exc:
+                clear_responses_reuse_state(session_id)
+                error_event = {
+                    "type": "error",
+                    "status_code": 502,
+                    "error": {"message": str(exc)},
+                }
+                if verbose:
+                    _log_json("STREAM OUT /v1/responses (bridge error)", error_event)
+                yield _encode_sse_event(error_event)
+                yield b"data: [DONE]\n\n"
+                return
+
+            if verbose:
+                _log_json("STREAM OUT /v1/responses (bridge event)", event)
+            note_responses_stream_event(session_id, event)
+            yield _encode_sse_event(event)
+            if _terminal_event(event):
+                yield b"data: [DONE]\n\n"
+                return
+    finally:
+        try:
+            upstream_ws.close()
+        except Exception:
+            pass
+
+
+def _collect_response(upstream_ws, *, session_id: str, verbose: bool) -> tuple[Dict[str, Any] | None, Dict[str, Any] | None, int]:
+    response_obj: Dict[str, Any] | None = None
+    try:
+        while True:
+            event = _recv_upstream_event(upstream_ws)
+            if verbose:
+                _log_json("STREAM OUT /v1/responses (bridge event)", event)
+            note_responses_stream_event(session_id, event)
+
+            response = event.get("response")
+            if isinstance(response, dict):
+                response_obj = response
+
+            event_type = event.get("type")
+            if event_type == "response.failed":
+                clear_responses_reuse_state(session_id)
+                error = response.get("error") if isinstance(response.get("error"), dict) else {"message": "response.failed"}
+                return None, {"error": error}, 502
+            if event_type == "error":
+                clear_responses_reuse_state(session_id)
+                error = event.get("error") if isinstance(event.get("error"), dict) else {"message": "Upstream websocket error"}
+                status_code = event.get("status_code") if isinstance(event.get("status_code"), int) else 502
+                return None, {"error": error}, status_code
+            if event_type == "response.completed":
+                return response_obj, None, 200
+    except ResponsesWebsocketBridgeProtocolError as exc:
+        clear_responses_reuse_state(session_id)
+        return None, {"error": {"message": str(exc)}}, 502
+    finally:
+        try:
+            upstream_ws.close()
+        except Exception:
+            pass
 
 
 def send_responses_request_via_websocket(
@@ -12,4 +187,69 @@ def send_responses_request_via_websocket(
     stream: bool,
     verbose: bool = False,
 ) -> Response:
-    raise NotImplementedError("WebSocket upstream bridge is not implemented yet.")
+    access_token, account_id = get_effective_chatgpt_auth()
+    if not access_token or not account_id:
+        clear_responses_reuse_state(session_id)
+        return _json_response(
+            {
+                "error": {
+                    "message": "Missing ChatGPT credentials. Run 'python3 chatmock.py login' first.",
+                }
+            },
+            status_code=401,
+        )
+
+    try:
+        upstream_ws = connect_upstream_websocket(
+            build_upstream_websocket_url(),
+            build_upstream_headers(
+                access_token,
+                account_id,
+                session_id,
+                accept="application/json",
+            ),
+        )
+    except Exception as exc:
+        clear_responses_reuse_state(session_id)
+        return _json_response(
+            {"error": {"message": f"Upstream websocket connection failed: {exc}"}},
+            status_code=502,
+        )
+
+    try:
+        _send_upstream_request(upstream_ws, payload, verbose=verbose)
+    except Exception as exc:
+        clear_responses_reuse_state(session_id)
+        try:
+            upstream_ws.close()
+        except Exception:
+            pass
+        return _json_response(
+            {"error": {"message": f"Upstream websocket request send failed: {exc}"}},
+            status_code=502,
+        )
+
+    if stream:
+        return _sse_response(
+            _iter_streaming_events(
+                upstream_ws,
+                session_id=session_id,
+                verbose=verbose,
+            )
+        )
+
+    response_obj, error_obj, status_code = _collect_response(
+        upstream_ws,
+        session_id=session_id,
+        verbose=verbose,
+    )
+    if error_obj is not None:
+        return _json_response(error_obj, status_code=status_code)
+    if response_obj is None:
+        clear_responses_reuse_state(session_id)
+        return _json_response(
+            {"error": {"message": "Upstream websocket closed before response.completed"}},
+            status_code=502,
+        )
+    note_responses_final_response(session_id, response_obj)
+    return _json_response(response_obj, status_code=status_code)

--- a/chatmock/responses_websocket_bridge.py
+++ b/chatmock/responses_websocket_bridge.py
@@ -62,6 +62,8 @@ def _previous_response_not_found_error(response_marker: str | None) -> Dict[str,
     if response_marker:
         message = f"No response found for previous_response_id {response_marker}."
     return {
+        "code": "previous_response_not_found",
+        "message": message,
         "error": {
             "message": message,
             "code": "previous_response_not_found",

--- a/chatmock/responses_websocket_bridge.py
+++ b/chatmock/responses_websocket_bridge.py
@@ -213,6 +213,7 @@ def _collect_response(
     retained_lease: RetainedUpstreamWebsocketLease | None = None,
 ) -> tuple[Dict[str, Any] | None, Dict[str, Any] | None, int]:
     response_obj: Dict[str, Any] | None = None
+    completed_output_items: list[Dict[str, Any]] = []
     retain_upstream = retained_lease is not None
     try:
         while True:
@@ -223,6 +224,11 @@ def _collect_response(
             event_type = event.get("type")
             if event_type != "response.completed":
                 note_responses_stream_event(session_id, event)
+
+            if event_type == "response.output_item.done":
+                item = event.get("item")
+                if isinstance(item, dict):
+                    completed_output_items.append(item)
 
             response = event.get("response")
             if isinstance(response, dict):
@@ -240,6 +246,10 @@ def _collect_response(
                 status_code = event.get("status_code") if isinstance(event.get("status_code"), int) else 502
                 return None, {"error": error}, status_code
             if event_type == "response.completed":
+                if isinstance(response_obj, dict):
+                    output = response_obj.get("output")
+                    if (not isinstance(output, list) or not output) and completed_output_items:
+                        response_obj = {**response_obj, "output": completed_output_items}
                 return response_obj, None, 200
     except ResponsesWebsocketBridgeProtocolError as exc:
         clear_responses_reuse_state(session_id)

--- a/chatmock/responses_websocket_bridge.py
+++ b/chatmock/responses_websocket_bridge.py
@@ -208,6 +208,7 @@ def _iter_streaming_events(
     retain_upstream = retained_lease is not None
     retained_response_id: str | None = None
     released = False
+    terminal_event_reached = False
     try:
         while True:
             try:
@@ -252,6 +253,7 @@ def _iter_streaming_events(
                 clear_responses_reuse_state(session_id)
                 retain_upstream = False
             if _terminal_event(event):
+                terminal_event_reached = True
                 _release_upstream_websocket(
                     upstream_ws,
                     retained_lease=retained_lease,
@@ -267,7 +269,7 @@ def _iter_streaming_events(
             _release_upstream_websocket(
                 upstream_ws,
                 retained_lease=retained_lease,
-                retain=retain_upstream,
+                retain=retain_upstream and terminal_event_reached,
                 response_id=retained_response_id,
             )
 
@@ -452,8 +454,6 @@ def send_responses_request_via_websocket(
             verbose=verbose,
             retained_lease=retained_lease,
         )
-        if retained_lease is not None:
-            return _sse_response(list(stream_iter))
         return _sse_response(stream_iter)
 
     response_obj, error_obj, status_code = _collect_response(

--- a/chatmock/responses_websocket_bridge.py
+++ b/chatmock/responses_websocket_bridge.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from flask import Response
+
+
+def send_responses_request_via_websocket(
+    *,
+    payload: Dict[str, Any],
+    session_id: str,
+    stream: bool,
+    verbose: bool = False,
+) -> Response:
+    raise NotImplementedError("WebSocket upstream bridge is not implemented yet.")

--- a/chatmock/responses_websocket_bridge.py
+++ b/chatmock/responses_websocket_bridge.py
@@ -135,7 +135,6 @@ def _iter_streaming_events(upstream_ws, *, session_id: str, verbose: bool):
                 if verbose:
                     _log_json("STREAM OUT /v1/responses (bridge error)", error_event)
                 yield _encode_sse_event(error_event)
-                yield b"data: [DONE]\n\n"
                 return
 
             if verbose:
@@ -143,7 +142,6 @@ def _iter_streaming_events(upstream_ws, *, session_id: str, verbose: bool):
             note_responses_stream_event(session_id, event)
             yield _encode_sse_event(event)
             if _terminal_event(event):
-                yield b"data: [DONE]\n\n"
                 return
     finally:
         try:

--- a/chatmock/responses_websocket_bridge.py
+++ b/chatmock/responses_websocket_bridge.py
@@ -7,6 +7,15 @@ from flask import Response, jsonify, make_response
 from websockets.exceptions import ConnectionClosed
 
 from .http import build_cors_headers
+from .responses_websocket_sessions import (
+    DEFAULT_MAX_RETAINED_UPSTREAM_WEBSOCKETS,
+    ResponsesWebsocketSessionCapacityError,
+    ResponsesWebsocketSessionConflictError,
+    RetainedUpstreamWebsocketLease,
+    acquire_retained_upstream_websocket,
+    evict_retained_upstream_websocket,
+    release_retained_upstream_websocket,
+)
 from .session import (
     clear_responses_reuse_state,
     note_responses_final_response,
@@ -127,13 +136,34 @@ def _send_upstream_request(upstream_ws, payload: Dict[str, Any], *, verbose: boo
     upstream_ws.send(json.dumps(request_event))
 
 
-def _iter_streaming_events(upstream_ws, *, session_id: str, verbose: bool):
+def _release_upstream_websocket(
+    upstream_ws,
+    *,
+    retained_lease: RetainedUpstreamWebsocketLease | None,
+    retain: bool,
+) -> None:
+    if retained_lease is None:
+        _close_request_upstream_websocket(upstream_ws)
+        return
+    release_retained_upstream_websocket(retained_lease, retain=retain)
+
+
+def _iter_streaming_events(
+    upstream_ws,
+    *,
+    session_id: str,
+    verbose: bool,
+    retained_lease: RetainedUpstreamWebsocketLease | None = None,
+):
+    retain_upstream = retained_lease is not None
+    released = False
     try:
         while True:
             try:
                 event = _recv_upstream_event(upstream_ws)
             except ResponsesWebsocketBridgeProtocolError as exc:
                 clear_responses_reuse_state(session_id)
+                retain_upstream = False
                 error_event = {
                     "type": "error",
                     "status_code": 502,
@@ -141,39 +171,71 @@ def _iter_streaming_events(upstream_ws, *, session_id: str, verbose: bool):
                 }
                 if verbose:
                     _log_json("STREAM OUT /v1/responses (bridge error)", error_event)
+                _release_upstream_websocket(
+                    upstream_ws,
+                    retained_lease=retained_lease,
+                    retain=retain_upstream,
+                )
+                released = True
                 yield _encode_sse_event(error_event)
                 return
 
             if verbose:
                 _log_json("STREAM OUT /v1/responses (bridge event)", event)
             note_responses_stream_event(session_id, event)
+            if event.get("type") in ("response.failed", "error"):
+                clear_responses_reuse_state(session_id)
+                retain_upstream = False
+            if _terminal_event(event):
+                _release_upstream_websocket(
+                    upstream_ws,
+                    retained_lease=retained_lease,
+                    retain=retain_upstream,
+                )
+                released = True
             yield _encode_sse_event(event)
             if _terminal_event(event):
                 return
     finally:
-        _close_request_upstream_websocket(upstream_ws)
+        if not released:
+            _release_upstream_websocket(
+                upstream_ws,
+                retained_lease=retained_lease,
+                retain=retain_upstream,
+            )
 
 
-def _collect_response(upstream_ws, *, session_id: str, verbose: bool) -> tuple[Dict[str, Any] | None, Dict[str, Any] | None, int]:
+def _collect_response(
+    upstream_ws,
+    *,
+    session_id: str,
+    verbose: bool,
+    retained_lease: RetainedUpstreamWebsocketLease | None = None,
+) -> tuple[Dict[str, Any] | None, Dict[str, Any] | None, int]:
     response_obj: Dict[str, Any] | None = None
+    retain_upstream = retained_lease is not None
     try:
         while True:
             event = _recv_upstream_event(upstream_ws)
             if verbose:
                 _log_json("STREAM OUT /v1/responses (bridge event)", event)
-            note_responses_stream_event(session_id, event)
+
+            event_type = event.get("type")
+            if event_type != "response.completed":
+                note_responses_stream_event(session_id, event)
 
             response = event.get("response")
             if isinstance(response, dict):
                 response_obj = response
 
-            event_type = event.get("type")
             if event_type == "response.failed":
                 clear_responses_reuse_state(session_id)
+                retain_upstream = False
                 error = response.get("error") if isinstance(response.get("error"), dict) else {"message": "response.failed"}
                 return None, {"error": error}, 502
             if event_type == "error":
                 clear_responses_reuse_state(session_id)
+                retain_upstream = False
                 error = event.get("error") if isinstance(event.get("error"), dict) else {"message": "Upstream websocket error"}
                 status_code = event.get("status_code") if isinstance(event.get("status_code"), int) else 502
                 return None, {"error": error}, status_code
@@ -181,9 +243,14 @@ def _collect_response(upstream_ws, *, session_id: str, verbose: bool) -> tuple[D
                 return response_obj, None, 200
     except ResponsesWebsocketBridgeProtocolError as exc:
         clear_responses_reuse_state(session_id)
+        retain_upstream = False
         return None, {"error": {"message": str(exc)}}, 502
     finally:
-        _close_request_upstream_websocket(upstream_ws)
+        _release_upstream_websocket(
+            upstream_ws,
+            retained_lease=retained_lease,
+            retain=retain_upstream,
+        )
 
 
 def send_responses_request_via_websocket(
@@ -192,11 +259,19 @@ def send_responses_request_via_websocket(
     session_id: str,
     stream: bool,
     verbose: bool = False,
+    stateful: bool = False,
+    explicit_previous_response_id: bool = False,
+    max_retained_sessions: int = DEFAULT_MAX_RETAINED_UPSTREAM_WEBSOCKETS,
 ) -> Response:
     # HTTP bridge mode is transport-only: one HTTP request owns one upstream
     # websocket connection, while session.py remains the only reuse-state owner.
+    if stateful and explicit_previous_response_id:
+        evict_retained_upstream_websocket(session_id)
+
     access_token, account_id = get_effective_chatgpt_auth()
     if not access_token or not account_id:
+        if stateful:
+            evict_retained_upstream_websocket(session_id)
         clear_responses_reuse_state(session_id)
         return _json_response(
             {
@@ -207,8 +282,8 @@ def send_responses_request_via_websocket(
             status_code=401,
         )
 
-    try:
-        upstream_ws = connect_upstream_websocket(
+    def _connect_upstream_websocket():
+        return connect_upstream_websocket(
             build_upstream_websocket_url(),
             build_upstream_headers(
                 access_token,
@@ -217,8 +292,33 @@ def send_responses_request_via_websocket(
                 accept="application/json",
             ),
         )
+
+    retained_lease: RetainedUpstreamWebsocketLease | None = None
+    try:
+        if stateful:
+            retained_lease = acquire_retained_upstream_websocket(
+                session_id,
+                _connect_upstream_websocket,
+                max_sessions=max_retained_sessions,
+            )
+            upstream_ws = retained_lease.upstream_ws
+        else:
+            upstream_ws = _connect_upstream_websocket()
+    except ResponsesWebsocketSessionConflictError as exc:
+        return _json_response(
+            {"error": {"message": str(exc)}},
+            status_code=409,
+        )
+    except ResponsesWebsocketSessionCapacityError as exc:
+        clear_responses_reuse_state(session_id)
+        return _json_response(
+            {"error": {"message": str(exc)}},
+            status_code=503,
+        )
     except Exception as exc:
         clear_responses_reuse_state(session_id)
+        if stateful:
+            evict_retained_upstream_websocket(session_id)
         return _json_response(
             {"error": {"message": f"Upstream websocket connection failed: {exc}"}},
             status_code=502,
@@ -228,25 +328,32 @@ def send_responses_request_via_websocket(
         _send_upstream_request(upstream_ws, payload, verbose=verbose)
     except Exception as exc:
         clear_responses_reuse_state(session_id)
-        _close_request_upstream_websocket(upstream_ws)
+        _release_upstream_websocket(
+            upstream_ws,
+            retained_lease=retained_lease,
+            retain=False,
+        )
         return _json_response(
             {"error": {"message": f"Upstream websocket request send failed: {exc}"}},
             status_code=502,
         )
 
     if stream:
-        return _sse_response(
-            _iter_streaming_events(
-                upstream_ws,
-                session_id=session_id,
-                verbose=verbose,
-            )
+        stream_iter = _iter_streaming_events(
+            upstream_ws,
+            session_id=session_id,
+            verbose=verbose,
+            retained_lease=retained_lease,
         )
+        if retained_lease is not None:
+            return _sse_response(list(stream_iter))
+        return _sse_response(stream_iter)
 
     response_obj, error_obj, status_code = _collect_response(
         upstream_ws,
         session_id=session_id,
         verbose=verbose,
+        retained_lease=retained_lease,
     )
     if error_obj is not None:
         return _json_response(error_obj, status_code=status_code)

--- a/chatmock/responses_websocket_bridge.py
+++ b/chatmock/responses_websocket_bridge.py
@@ -20,6 +20,13 @@ class ResponsesWebsocketBridgeProtocolError(ValueError):
     pass
 
 
+def _close_request_upstream_websocket(upstream_ws) -> None:
+    try:
+        upstream_ws.close()
+    except Exception:
+        pass
+
+
 def _log_json(prefix: str, payload: Any) -> None:
     try:
         print(f"{prefix}\n{json.dumps(payload, indent=2, ensure_ascii=False)}")
@@ -144,10 +151,7 @@ def _iter_streaming_events(upstream_ws, *, session_id: str, verbose: bool):
             if _terminal_event(event):
                 return
     finally:
-        try:
-            upstream_ws.close()
-        except Exception:
-            pass
+        _close_request_upstream_websocket(upstream_ws)
 
 
 def _collect_response(upstream_ws, *, session_id: str, verbose: bool) -> tuple[Dict[str, Any] | None, Dict[str, Any] | None, int]:
@@ -179,10 +183,7 @@ def _collect_response(upstream_ws, *, session_id: str, verbose: bool) -> tuple[D
         clear_responses_reuse_state(session_id)
         return None, {"error": {"message": str(exc)}}, 502
     finally:
-        try:
-            upstream_ws.close()
-        except Exception:
-            pass
+        _close_request_upstream_websocket(upstream_ws)
 
 
 def send_responses_request_via_websocket(
@@ -192,6 +193,8 @@ def send_responses_request_via_websocket(
     stream: bool,
     verbose: bool = False,
 ) -> Response:
+    # HTTP bridge mode is transport-only: one HTTP request owns one upstream
+    # websocket connection, while session.py remains the only reuse-state owner.
     access_token, account_id = get_effective_chatgpt_auth()
     if not access_token or not account_id:
         clear_responses_reuse_state(session_id)
@@ -225,10 +228,7 @@ def send_responses_request_via_websocket(
         _send_upstream_request(upstream_ws, payload, verbose=verbose)
     except Exception as exc:
         clear_responses_reuse_state(session_id)
-        try:
-            upstream_ws.close()
-        except Exception:
-            pass
+        _close_request_upstream_websocket(upstream_ws)
         return _json_response(
             {"error": {"message": f"Upstream websocket request send failed: {exc}"}},
             status_code=502,

--- a/chatmock/responses_websocket_bridge.py
+++ b/chatmock/responses_websocket_bridge.py
@@ -107,10 +107,17 @@ def _encode_sse_event(event: Dict[str, Any]) -> bytes:
     return ("data: " + payload + "\n\n").encode("utf-8")
 
 
+def _build_upstream_request_event(payload: Dict[str, Any]) -> Dict[str, Any]:
+    if payload.get("type") == "response.create":
+        return payload
+    return {"type": "response.create", **payload}
+
+
 def _send_upstream_request(upstream_ws, payload: Dict[str, Any], *, verbose: bool) -> None:
+    request_event = _build_upstream_request_event(payload)
     if verbose:
-        _log_json("OUTBOUND >> ChatGPT Responses WS payload", payload)
-    upstream_ws.send(json.dumps(payload))
+        _log_json("OUTBOUND >> ChatGPT Responses WS payload", request_event)
+    upstream_ws.send(json.dumps(request_event))
 
 
 def _iter_streaming_events(upstream_ws, *, session_id: str, verbose: bool):

--- a/chatmock/responses_websocket_bridge.py
+++ b/chatmock/responses_websocket_bridge.py
@@ -155,6 +155,31 @@ def _send_upstream_request(upstream_ws, payload: Dict[str, Any], *, verbose: boo
     upstream_ws.send(json.dumps(request_event))
 
 
+def _normalize_completed_response_event(
+    event: Dict[str, Any],
+    *,
+    completed_output_items: list[Dict[str, Any]],
+) -> Dict[str, Any]:
+    if event.get("type") != "response.completed":
+        return event
+
+    response = event.get("response")
+    if not isinstance(response, dict):
+        return event
+
+    if isinstance(response.get("output"), list):
+        return event
+
+    normalized_output = completed_output_items if completed_output_items else []
+    return {
+        **event,
+        "response": {
+            **response,
+            "output": normalized_output,
+        },
+    }
+
+
 def _release_upstream_websocket(
     upstream_ws,
     *,
@@ -179,6 +204,7 @@ def _iter_streaming_events(
     verbose: bool,
     retained_lease: RetainedUpstreamWebsocketLease | None = None,
 ):
+    completed_output_items: list[Dict[str, Any]] = []
     retain_upstream = retained_lease is not None
     retained_response_id: str | None = None
     released = False
@@ -204,6 +230,17 @@ def _iter_streaming_events(
                 released = True
                 yield _encode_sse_event(error_event)
                 return
+
+            event_type = event.get("type")
+            if event_type == "response.output_item.done":
+                item = event.get("item")
+                if isinstance(item, dict):
+                    completed_output_items.append(item)
+            elif event_type == "response.completed":
+                event = _normalize_completed_response_event(
+                    event,
+                    completed_output_items=completed_output_items,
+                )
 
             if verbose:
                 _log_json("STREAM OUT /v1/responses (bridge event)", event)
@@ -250,17 +287,22 @@ def _collect_response(
     try:
         while True:
             event = _recv_upstream_event(upstream_ws)
-            if verbose:
-                _log_json("STREAM OUT /v1/responses (bridge event)", event)
-
             event_type = event.get("type")
-            if event_type != "response.completed":
-                note_responses_stream_event(session_id, event)
-
             if event_type == "response.output_item.done":
                 item = event.get("item")
                 if isinstance(item, dict):
                     completed_output_items.append(item)
+            elif event_type == "response.completed":
+                event = _normalize_completed_response_event(
+                    event,
+                    completed_output_items=completed_output_items,
+                )
+
+            if verbose:
+                _log_json("STREAM OUT /v1/responses (bridge event)", event)
+
+            if event_type != "response.completed":
+                note_responses_stream_event(session_id, event)
 
             response = event.get("response")
             if isinstance(response, dict):
@@ -284,10 +326,6 @@ def _collect_response(
                 status_code = event.get("status_code") if isinstance(event.get("status_code"), int) else 502
                 return None, {"error": error}, status_code
             if event_type == "response.completed":
-                if isinstance(response_obj, dict):
-                    output = response_obj.get("output")
-                    if (not isinstance(output, list) or not output) and completed_output_items:
-                        response_obj = {**response_obj, "output": completed_output_items}
                 return response_obj, None, 200
     except ResponsesWebsocketBridgeProtocolError as exc:
         clear_responses_reuse_state(session_id)

--- a/chatmock/responses_websocket_bridge.py
+++ b/chatmock/responses_websocket_bridge.py
@@ -413,12 +413,7 @@ def send_responses_request_via_websocket(
         clear_responses_reuse_state(session_id)
         if stateful and response_marker:
             evict_retained_upstream_websocket(response_marker)
-        if not stateful and isinstance(exc, RuntimeError) and str(exc).startswith("Missing ChatGPT credentials"):
-            return _json_response(
-                {"error": {"message": str(exc)}},
-                status_code=401,
-            )
-        if stateful and isinstance(exc, RuntimeError) and str(exc).startswith("Missing ChatGPT credentials"):
+        if isinstance(exc, RuntimeError) and str(exc).startswith("Missing ChatGPT credentials"):
             return _json_response(
                 {"error": {"message": str(exc)}},
                 status_code=401,

--- a/chatmock/responses_websocket_bridge.py
+++ b/chatmock/responses_websocket_bridge.py
@@ -11,6 +11,7 @@ from .responses_websocket_sessions import (
     DEFAULT_MAX_RETAINED_UPSTREAM_WEBSOCKETS,
     ResponsesWebsocketSessionCapacityError,
     ResponsesWebsocketSessionConflictError,
+    ResponsesWebsocketSessionNotFoundError,
     RetainedUpstreamWebsocketLease,
     acquire_retained_upstream_websocket,
     evict_retained_upstream_websocket,
@@ -141,11 +142,16 @@ def _release_upstream_websocket(
     *,
     retained_lease: RetainedUpstreamWebsocketLease | None,
     retain: bool,
+    response_id: str | None = None,
 ) -> None:
     if retained_lease is None:
         _close_request_upstream_websocket(upstream_ws)
         return
-    release_retained_upstream_websocket(retained_lease, retain=retain)
+    release_retained_upstream_websocket(
+        retained_lease,
+        retain=retain,
+        response_id=response_id,
+    )
 
 
 def _iter_streaming_events(
@@ -156,6 +162,7 @@ def _iter_streaming_events(
     retained_lease: RetainedUpstreamWebsocketLease | None = None,
 ):
     retain_upstream = retained_lease is not None
+    retained_response_id: str | None = None
     released = False
     try:
         while True:
@@ -183,6 +190,9 @@ def _iter_streaming_events(
             if verbose:
                 _log_json("STREAM OUT /v1/responses (bridge event)", event)
             note_responses_stream_event(session_id, event)
+            response = event.get("response")
+            if isinstance(response, dict) and isinstance(response.get("id"), str):
+                retained_response_id = response.get("id")
             if event.get("type") in ("response.failed", "error"):
                 clear_responses_reuse_state(session_id)
                 retain_upstream = False
@@ -191,6 +201,7 @@ def _iter_streaming_events(
                     upstream_ws,
                     retained_lease=retained_lease,
                     retain=retain_upstream,
+                    response_id=retained_response_id,
                 )
                 released = True
             yield _encode_sse_event(event)
@@ -202,6 +213,7 @@ def _iter_streaming_events(
                 upstream_ws,
                 retained_lease=retained_lease,
                 retain=retain_upstream,
+                response_id=retained_response_id,
             )
 
 
@@ -215,6 +227,7 @@ def _collect_response(
     response_obj: Dict[str, Any] | None = None
     completed_output_items: list[Dict[str, Any]] = []
     retain_upstream = retained_lease is not None
+    retained_response_id: str | None = None
     try:
         while True:
             event = _recv_upstream_event(upstream_ws)
@@ -233,6 +246,8 @@ def _collect_response(
             response = event.get("response")
             if isinstance(response, dict):
                 response_obj = response
+                if isinstance(response.get("id"), str):
+                    retained_response_id = response.get("id")
 
             if event_type == "response.failed":
                 clear_responses_reuse_state(session_id)
@@ -260,6 +275,7 @@ def _collect_response(
             upstream_ws,
             retained_lease=retained_lease,
             retain=retain_upstream,
+            response_id=retained_response_id,
         )
 
 
@@ -273,26 +289,27 @@ def send_responses_request_via_websocket(
     explicit_previous_response_id: bool = False,
     max_retained_sessions: int = DEFAULT_MAX_RETAINED_UPSTREAM_WEBSOCKETS,
 ) -> Response:
-    # HTTP bridge mode is transport-only: one HTTP request owns one upstream
-    # websocket connection, while session.py remains the only reuse-state owner.
-    if stateful and explicit_previous_response_id:
-        evict_retained_upstream_websocket(session_id)
+    explicit_previous_response_id_value = payload.get("previous_response_id")
+    response_marker = (
+        explicit_previous_response_id_value.strip()
+        if stateful
+        and explicit_previous_response_id
+        and isinstance(explicit_previous_response_id_value, str)
+        and explicit_previous_response_id_value.strip()
+        else None
+    )
 
-    access_token, account_id = get_effective_chatgpt_auth()
-    if not access_token or not account_id:
-        if stateful:
-            evict_retained_upstream_websocket(session_id)
-        clear_responses_reuse_state(session_id)
-        return _json_response(
-            {
-                "error": {
-                    "message": "Missing ChatGPT credentials. Run 'python3 chatmock.py login' first.",
-                }
-            },
-            status_code=401,
-        )
+    access_token: str | None = None
+    account_id: str | None = None
 
     def _connect_upstream_websocket():
+        nonlocal access_token, account_id
+        if access_token is None or account_id is None:
+            access_token, account_id = get_effective_chatgpt_auth()
+        if not access_token or not account_id:
+            raise RuntimeError(
+                "Missing ChatGPT credentials. Run 'python3 chatmock.py login' first."
+            )
         return connect_upstream_websocket(
             build_upstream_websocket_url(),
             build_upstream_headers(
@@ -307,13 +324,23 @@ def send_responses_request_via_websocket(
     try:
         if stateful:
             retained_lease = acquire_retained_upstream_websocket(
-                session_id,
+                response_marker,
                 _connect_upstream_websocket,
                 max_sessions=max_retained_sessions,
             )
             upstream_ws = retained_lease.upstream_ws
         else:
             upstream_ws = _connect_upstream_websocket()
+    except ResponsesWebsocketSessionNotFoundError:
+        return _json_response(
+            {
+                "error": {
+                    "message": f"No response found for previous_response_id {response_marker}.",
+                    "code": "previous_response_not_found",
+                }
+            },
+            status_code=400,
+        )
     except ResponsesWebsocketSessionConflictError as exc:
         return _json_response(
             {"error": {"message": str(exc)}},
@@ -327,8 +354,18 @@ def send_responses_request_via_websocket(
         )
     except Exception as exc:
         clear_responses_reuse_state(session_id)
-        if stateful:
-            evict_retained_upstream_websocket(session_id)
+        if stateful and response_marker:
+            evict_retained_upstream_websocket(response_marker)
+        if not stateful and isinstance(exc, RuntimeError) and str(exc).startswith("Missing ChatGPT credentials"):
+            return _json_response(
+                {"error": {"message": str(exc)}},
+                status_code=401,
+            )
+        if stateful and isinstance(exc, RuntimeError) and str(exc).startswith("Missing ChatGPT credentials"):
+            return _json_response(
+                {"error": {"message": str(exc)}},
+                status_code=401,
+            )
         return _json_response(
             {"error": {"message": f"Upstream websocket connection failed: {exc}"}},
             status_code=502,

--- a/chatmock/responses_websocket_sessions.py
+++ b/chatmock/responses_websocket_sessions.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import threading
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Any, Callable
+
+
+DEFAULT_MAX_RETAINED_UPSTREAM_WEBSOCKETS = 1000
+_LOCK = threading.Lock()
+
+
+class ResponsesWebsocketSessionConflictError(RuntimeError):
+    pass
+
+
+class ResponsesWebsocketSessionCapacityError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class RetainedUpstreamWebsocketLease:
+    session_id: str
+    upstream_ws: Any
+    created: bool
+
+
+@dataclass
+class _RetainedUpstreamWebsocketEntry:
+    upstream_ws: Any
+    in_use: bool
+    last_used: float
+
+
+_SESSIONS: OrderedDict[str, _RetainedUpstreamWebsocketEntry] = OrderedDict()
+
+
+def _close_upstream_websocket(upstream_ws: Any) -> None:
+    try:
+        upstream_ws.close()
+    except Exception:
+        pass
+
+
+def _normalize_max_sessions(max_sessions: int) -> int:
+    if not isinstance(max_sessions, int):
+        return DEFAULT_MAX_RETAINED_UPSTREAM_WEBSOCKETS
+    return max(1, max_sessions)
+
+
+def _is_upstream_websocket_marked_closed(upstream_ws: Any) -> bool:
+    try:
+        if bool(getattr(upstream_ws, "closed", False)):
+            return True
+    except Exception:
+        pass
+    try:
+        if getattr(upstream_ws, "close_code", None) is not None:
+            return True
+    except Exception:
+        pass
+    return False
+
+
+def _close_entry_locked(session_id: str) -> None:
+    entry = _SESSIONS.pop(session_id, None)
+    if entry is None:
+        return
+    _close_upstream_websocket(entry.upstream_ws)
+
+
+def _evict_closed_entries_locked() -> None:
+    for session_id, entry in list(_SESSIONS.items()):
+        if entry.in_use:
+            continue
+        if _is_upstream_websocket_marked_closed(entry.upstream_ws):
+            _close_entry_locked(session_id)
+
+
+def _evict_to_capacity_locked(max_sessions: int) -> None:
+    _evict_closed_entries_locked()
+    while len(_SESSIONS) >= max_sessions:
+        evicted = False
+        for session_id, entry in list(_SESSIONS.items()):
+            if entry.in_use:
+                continue
+            _close_entry_locked(session_id)
+            evicted = True
+            break
+        if not evicted:
+            raise ResponsesWebsocketSessionCapacityError(
+                "Too many retained upstream websocket sessions are active right now."
+            )
+
+
+def acquire_retained_upstream_websocket(
+    session_id: str,
+    create_upstream_websocket: Callable[[], Any],
+    *,
+    max_sessions: int = DEFAULT_MAX_RETAINED_UPSTREAM_WEBSOCKETS,
+) -> RetainedUpstreamWebsocketLease:
+    effective_max_sessions = _normalize_max_sessions(max_sessions)
+    now = time.monotonic()
+
+    with _LOCK:
+        entry = _SESSIONS.get(session_id)
+        if entry is not None:
+            if entry.in_use:
+                raise ResponsesWebsocketSessionConflictError(
+                    f"A stateful HTTP websocket bridge request for session '{session_id}' is already in progress."
+                )
+            if _is_upstream_websocket_marked_closed(entry.upstream_ws):
+                _close_entry_locked(session_id)
+                entry = None
+
+        if entry is None:
+            _evict_to_capacity_locked(effective_max_sessions)
+            upstream_ws = create_upstream_websocket()
+            _SESSIONS[session_id] = _RetainedUpstreamWebsocketEntry(
+                upstream_ws=upstream_ws,
+                in_use=True,
+                last_used=now,
+            )
+            return RetainedUpstreamWebsocketLease(
+                session_id=session_id,
+                upstream_ws=upstream_ws,
+                created=True,
+            )
+
+        entry.in_use = True
+        entry.last_used = now
+        _SESSIONS.move_to_end(session_id)
+        return RetainedUpstreamWebsocketLease(
+            session_id=session_id,
+            upstream_ws=entry.upstream_ws,
+            created=False,
+        )
+
+
+def release_retained_upstream_websocket(
+    lease: RetainedUpstreamWebsocketLease,
+    *,
+    retain: bool,
+) -> None:
+    with _LOCK:
+        entry = _SESSIONS.get(lease.session_id)
+        if entry is None or entry.upstream_ws is not lease.upstream_ws:
+            if not retain:
+                _close_upstream_websocket(lease.upstream_ws)
+            return
+
+        if retain and not _is_upstream_websocket_marked_closed(entry.upstream_ws):
+            entry.in_use = False
+            entry.last_used = time.monotonic()
+            _SESSIONS.move_to_end(lease.session_id)
+            return
+
+        _close_entry_locked(lease.session_id)
+
+
+def evict_retained_upstream_websocket(session_id: str) -> None:
+    with _LOCK:
+        _close_entry_locked(session_id)
+
+
+def reset_retained_upstream_websocket_sessions() -> None:
+    with _LOCK:
+        for session_id in list(_SESSIONS.keys()):
+            _close_entry_locked(session_id)

--- a/chatmock/responses_websocket_sessions.py
+++ b/chatmock/responses_websocket_sessions.py
@@ -19,9 +19,13 @@ class ResponsesWebsocketSessionCapacityError(RuntimeError):
     pass
 
 
+class ResponsesWebsocketSessionNotFoundError(RuntimeError):
+    pass
+
+
 @dataclass(frozen=True)
 class RetainedUpstreamWebsocketLease:
-    session_id: str
+    response_id: str | None
     upstream_ws: Any
     created: bool
 
@@ -34,6 +38,7 @@ class _RetainedUpstreamWebsocketEntry:
 
 
 _SESSIONS: OrderedDict[str, _RetainedUpstreamWebsocketEntry] = OrderedDict()
+_ANONYMOUS_LEASES: dict[int, Any] = {}
 
 
 def _close_upstream_websocket(upstream_ws: Any) -> None:
@@ -63,29 +68,33 @@ def _is_upstream_websocket_marked_closed(upstream_ws: Any) -> bool:
     return False
 
 
-def _close_entry_locked(session_id: str) -> None:
-    entry = _SESSIONS.pop(session_id, None)
+def _close_entry_locked(response_id: str) -> None:
+    entry = _SESSIONS.pop(response_id, None)
     if entry is None:
         return
     _close_upstream_websocket(entry.upstream_ws)
 
 
 def _evict_closed_entries_locked() -> None:
-    for session_id, entry in list(_SESSIONS.items()):
+    for response_id, entry in list(_SESSIONS.items()):
         if entry.in_use:
             continue
         if _is_upstream_websocket_marked_closed(entry.upstream_ws):
-            _close_entry_locked(session_id)
+            _close_entry_locked(response_id)
+
+
+def _active_session_count_locked() -> int:
+    return len(_SESSIONS) + len(_ANONYMOUS_LEASES)
 
 
 def _evict_to_capacity_locked(max_sessions: int) -> None:
     _evict_closed_entries_locked()
-    while len(_SESSIONS) >= max_sessions:
+    while _active_session_count_locked() >= max_sessions:
         evicted = False
-        for session_id, entry in list(_SESSIONS.items()):
+        for response_id, entry in list(_SESSIONS.items()):
             if entry.in_use:
                 continue
-            _close_entry_locked(session_id)
+            _close_entry_locked(response_id)
             evicted = True
             break
         if not evicted:
@@ -94,45 +103,56 @@ def _evict_to_capacity_locked(max_sessions: int) -> None:
             )
 
 
+def _normalize_response_id(response_id: str | None) -> str | None:
+    if not isinstance(response_id, str):
+        return None
+    normalized = response_id.strip()
+    return normalized or None
+
+
 def acquire_retained_upstream_websocket(
-    session_id: str,
+    response_id: str | None,
     create_upstream_websocket: Callable[[], Any],
     *,
     max_sessions: int = DEFAULT_MAX_RETAINED_UPSTREAM_WEBSOCKETS,
 ) -> RetainedUpstreamWebsocketLease:
     effective_max_sessions = _normalize_max_sessions(max_sessions)
     now = time.monotonic()
+    normalized_response_id = _normalize_response_id(response_id)
 
     with _LOCK:
-        entry = _SESSIONS.get(session_id)
+        entry = None
+        if normalized_response_id is not None:
+            entry = _SESSIONS.get(normalized_response_id)
         if entry is not None:
             if entry.in_use:
                 raise ResponsesWebsocketSessionConflictError(
-                    f"A stateful HTTP websocket bridge request for session '{session_id}' is already in progress."
+                    f"A stateful HTTP websocket bridge request for response '{normalized_response_id}' is already in progress."
                 )
             if _is_upstream_websocket_marked_closed(entry.upstream_ws):
-                _close_entry_locked(session_id)
+                _close_entry_locked(normalized_response_id)
                 entry = None
+
+        if entry is None and normalized_response_id is not None:
+            raise ResponsesWebsocketSessionNotFoundError(
+                f"No retained upstream websocket exists for response '{normalized_response_id}'."
+            )
 
         if entry is None:
             _evict_to_capacity_locked(effective_max_sessions)
             upstream_ws = create_upstream_websocket()
-            _SESSIONS[session_id] = _RetainedUpstreamWebsocketEntry(
-                upstream_ws=upstream_ws,
-                in_use=True,
-                last_used=now,
-            )
+            _ANONYMOUS_LEASES[id(upstream_ws)] = upstream_ws
             return RetainedUpstreamWebsocketLease(
-                session_id=session_id,
+                response_id=None,
                 upstream_ws=upstream_ws,
                 created=True,
             )
 
         entry.in_use = True
         entry.last_used = now
-        _SESSIONS.move_to_end(session_id)
+        _SESSIONS.move_to_end(normalized_response_id)
         return RetainedUpstreamWebsocketLease(
-            session_id=session_id,
+            response_id=normalized_response_id,
             upstream_ws=entry.upstream_ws,
             created=False,
         )
@@ -142,29 +162,58 @@ def release_retained_upstream_websocket(
     lease: RetainedUpstreamWebsocketLease,
     *,
     retain: bool,
+    response_id: str | None = None,
 ) -> None:
+    retained_response_id = _normalize_response_id(response_id) or lease.response_id
     with _LOCK:
-        entry = _SESSIONS.get(lease.session_id)
+        anonymous_upstream = _ANONYMOUS_LEASES.pop(id(lease.upstream_ws), None)
+        if anonymous_upstream is not None:
+            if retain and retained_response_id and not _is_upstream_websocket_marked_closed(lease.upstream_ws):
+                _SESSIONS[retained_response_id] = _RetainedUpstreamWebsocketEntry(
+                    upstream_ws=lease.upstream_ws,
+                    in_use=False,
+                    last_used=time.monotonic(),
+                )
+                _SESSIONS.move_to_end(retained_response_id)
+                return
+            _close_upstream_websocket(lease.upstream_ws)
+            return
+
+        if lease.response_id is None:
+            if not retain:
+                _close_upstream_websocket(lease.upstream_ws)
+            return
+
+        entry = _SESSIONS.get(lease.response_id)
         if entry is None or entry.upstream_ws is not lease.upstream_ws:
             if not retain:
                 _close_upstream_websocket(lease.upstream_ws)
             return
 
-        if retain and not _is_upstream_websocket_marked_closed(entry.upstream_ws):
+        if retain and retained_response_id and not _is_upstream_websocket_marked_closed(entry.upstream_ws):
+            if retained_response_id != lease.response_id:
+                _SESSIONS.pop(lease.response_id, None)
+                _SESSIONS[retained_response_id] = entry
             entry.in_use = False
             entry.last_used = time.monotonic()
-            _SESSIONS.move_to_end(lease.session_id)
+            _SESSIONS.move_to_end(retained_response_id)
             return
 
-        _close_entry_locked(lease.session_id)
+        _close_entry_locked(lease.response_id)
 
 
-def evict_retained_upstream_websocket(session_id: str) -> None:
+def evict_retained_upstream_websocket(response_id: str | None) -> None:
+    normalized_response_id = _normalize_response_id(response_id)
+    if normalized_response_id is None:
+        return
     with _LOCK:
-        _close_entry_locked(session_id)
+        _close_entry_locked(normalized_response_id)
 
 
 def reset_retained_upstream_websocket_sessions() -> None:
     with _LOCK:
-        for session_id in list(_SESSIONS.keys()):
-            _close_entry_locked(session_id)
+        for response_id in list(_SESSIONS.keys()):
+            _close_entry_locked(response_id)
+        for upstream_ws in list(_ANONYMOUS_LEASES.values()):
+            _close_upstream_websocket(upstream_ws)
+        _ANONYMOUS_LEASES.clear()

--- a/chatmock/responses_websocket_sessions.py
+++ b/chatmock/responses_websocket_sessions.py
@@ -37,8 +37,15 @@ class _RetainedUpstreamWebsocketEntry:
     last_used: float
 
 
+@dataclass(frozen=True)
+class _PendingUpstreamWebsocketReservation:
+    token: object
+    last_used: float
+
+
 _SESSIONS: OrderedDict[str, _RetainedUpstreamWebsocketEntry] = OrderedDict()
 _ANONYMOUS_LEASES: dict[int, Any] = {}
+_PENDING_ANONYMOUS_RESERVATIONS: dict[int, _PendingUpstreamWebsocketReservation] = {}
 
 
 def _close_upstream_websocket(upstream_ws: Any) -> None:
@@ -84,7 +91,11 @@ def _evict_closed_entries_locked() -> None:
 
 
 def _active_session_count_locked() -> int:
-    return len(_SESSIONS) + len(_ANONYMOUS_LEASES)
+    return (
+        len(_SESSIONS)
+        + len(_ANONYMOUS_LEASES)
+        + len(_PENDING_ANONYMOUS_RESERVATIONS)
+    )
 
 
 def _evict_to_capacity_locked(max_sessions: int) -> None:
@@ -119,6 +130,7 @@ def acquire_retained_upstream_websocket(
     effective_max_sessions = _normalize_max_sessions(max_sessions)
     now = time.monotonic()
     normalized_response_id = _normalize_response_id(response_id)
+    reservation_token: object | None = None
 
     with _LOCK:
         entry = None
@@ -140,21 +152,38 @@ def acquire_retained_upstream_websocket(
 
         if entry is None:
             _evict_to_capacity_locked(effective_max_sessions)
-            upstream_ws = create_upstream_websocket()
-            _ANONYMOUS_LEASES[id(upstream_ws)] = upstream_ws
+            reservation_token = object()
+            _PENDING_ANONYMOUS_RESERVATIONS[id(reservation_token)] = _PendingUpstreamWebsocketReservation(
+                token=reservation_token,
+                last_used=now,
+            )
+        else:
+            entry.in_use = True
+            entry.last_used = now
+            _SESSIONS.move_to_end(normalized_response_id)
             return RetainedUpstreamWebsocketLease(
-                response_id=None,
-                upstream_ws=upstream_ws,
-                created=True,
+                response_id=normalized_response_id,
+                upstream_ws=entry.upstream_ws,
+                created=False,
             )
 
-        entry.in_use = True
-        entry.last_used = now
-        _SESSIONS.move_to_end(normalized_response_id)
+    if reservation_token is None:
+        raise RuntimeError("Anonymous upstream websocket reservation was not created.")
+
+    try:
+        upstream_ws = create_upstream_websocket()
+    except Exception:
+        with _LOCK:
+            _PENDING_ANONYMOUS_RESERVATIONS.pop(id(reservation_token), None)
+        raise
+
+    with _LOCK:
+        _PENDING_ANONYMOUS_RESERVATIONS.pop(id(reservation_token), None)
+        _ANONYMOUS_LEASES[id(upstream_ws)] = upstream_ws
         return RetainedUpstreamWebsocketLease(
-            response_id=normalized_response_id,
-            upstream_ws=entry.upstream_ws,
-            created=False,
+            response_id=None,
+            upstream_ws=upstream_ws,
+            created=True,
         )
 
 
@@ -217,3 +246,4 @@ def reset_retained_upstream_websocket_sessions() -> None:
         for upstream_ws in list(_ANONYMOUS_LEASES.values()):
             _close_upstream_websocket(upstream_ws)
         _ANONYMOUS_LEASES.clear()
+        _PENDING_ANONYMOUS_RESERVATIONS.clear()

--- a/chatmock/routes_openai.py
+++ b/chatmock/routes_openai.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List
 
 from flask import Blueprint, Response, current_app, jsonify, make_response, request
 
+from . import responses_websocket_bridge
 from .config import BASE_INSTRUCTIONS, GPT5_CODEX_INSTRUCTIONS
 from .fast_mode import resolve_service_tier
 from .limits import record_rate_limits_from_response

--- a/chatmock/routes_openai.py
+++ b/chatmock/routes_openai.py
@@ -59,18 +59,6 @@ def _error_json_response(message: str, status_code: int) -> Response:
     return resp
 
 
-def _require_explicit_stateful_http_session_id() -> tuple[str | None, Response | None]:
-    client_session_id = extract_client_session_id(request.headers)
-    if isinstance(client_session_id, str):
-        client_session_id = client_session_id.strip()
-    if client_session_id:
-        return client_session_id, None
-    return None, _error_json_response(
-        "Stateful HTTP websocket bridge mode requires a non-empty X-Session-Id or session_id header.",
-        400,
-    )
-
-
 def _log_json(prefix: str, payload: Any) -> None:
     try:
         print(f"{prefix}\n{json.dumps(payload, indent=2, ensure_ascii=False)}")
@@ -625,15 +613,6 @@ def responses_create() -> Response:
         return jsonify(err), 400
 
     client_session_id = extract_client_session_id(request.headers)
-    if stateful_http_bridge_enabled:
-        client_session_id, error_resp = _require_explicit_stateful_http_session_id()
-        if error_resp is not None:
-            if verbose:
-                _log_json(
-                    "OUT POST /v1/responses",
-                    {"error": {"message": error_resp.get_json()["error"]["message"]}},
-                )
-            return error_resp
 
     try:
         normalized = normalize_responses_payload(
@@ -652,13 +631,27 @@ def responses_create() -> Response:
     if normalized.service_tier_resolution.warning_message and verbose:
         print(f"[FastMode] {normalized.service_tier_resolution.warning_message}")
 
-    prepared = prepare_responses_request_for_session(
-        normalized.session_id,
-        normalized.payload,
-        allow_previous_response_id=stateful_http_bridge_enabled,
+    explicit_previous_response_id = (
+        isinstance(normalized.payload.get("previous_response_id"), str)
+        and bool(normalized.payload.get("previous_response_id").strip())
     )
-    stream_req = bool(prepared.payload.get("stream", False))
-    upstream_request_payload = dict(prepared.payload)
+    if stateful_http_bridge_enabled:
+        prepared_payload = dict(normalized.payload)
+        if not explicit_previous_response_id:
+            prepared_payload.pop("previous_response_id", None)
+    else:
+        prepared = prepare_responses_request_for_session(
+            normalized.session_id,
+            normalized.payload,
+            allow_previous_response_id=False,
+        )
+        prepared_payload = dict(prepared.payload)
+        explicit_previous_response_id = bool(
+            getattr(prepared, "explicit_previous_response_id", False)
+        )
+
+    stream_req = bool(prepared_payload.get("stream", False))
+    upstream_request_payload = dict(prepared_payload)
     upstream_request_payload["stream"] = True
     if bool(current_app.config.get("RESPONSES_WEBSOCKET_UPSTREAM")):
         # The HTTP bridge owns one upstream websocket per HTTP request.
@@ -668,11 +661,7 @@ def responses_create() -> Response:
             stream=stream_req,
             verbose=verbose,
             stateful=stateful_http_bridge_enabled,
-            explicit_previous_response_id=getattr(
-                prepared,
-                "explicit_previous_response_id",
-                False,
-            ),
+            explicit_previous_response_id=explicit_previous_response_id,
             max_retained_sessions=current_app.config.get(
                 "RESPONSES_WEBSOCKET_UPSTREAM_MAX_RETAINED_SESSIONS"
             ),

--- a/chatmock/routes_openai.py
+++ b/chatmock/routes_openai.py
@@ -43,6 +43,10 @@ from .utils import (
 
 openai_bp = Blueprint("openai", __name__)
 
+# HTTP /v1/responses stays transport-only. Only the frontend websocket route
+# opts into previous_response_id reuse semantics through session.py.
+HTTP_RESPONSES_ALLOW_PREVIOUS_RESPONSE_ID = False
+
 
 def _log_json(prefix: str, payload: Any) -> None:
     try:
@@ -616,21 +620,22 @@ def responses_create() -> Response:
     prepared = prepare_responses_request_for_session(
         normalized.session_id,
         normalized.payload,
-        allow_previous_response_id=False,
+        allow_previous_response_id=HTTP_RESPONSES_ALLOW_PREVIOUS_RESPONSE_ID,
     )
     stream_req = bool(prepared.payload.get("stream", False))
-    upstream_payload = dict(prepared.payload)
-    upstream_payload["stream"] = True
+    upstream_request_payload = dict(prepared.payload)
+    upstream_request_payload["stream"] = True
     if bool(current_app.config.get("RESPONSES_WEBSOCKET_UPSTREAM")):
+        # The HTTP bridge owns one upstream websocket per HTTP request.
         return responses_websocket_bridge.send_responses_request_via_websocket(
-            payload=upstream_payload,
+            payload=upstream_request_payload,
             session_id=normalized.session_id,
             stream=stream_req,
             verbose=verbose,
         )
 
     upstream, error_resp = start_upstream_raw_request(
-        upstream_payload,
+        upstream_request_payload,
         session_id=normalized.session_id,
         stream=True,
     )

--- a/chatmock/routes_openai.py
+++ b/chatmock/routes_openai.py
@@ -667,6 +667,12 @@ def responses_create() -> Response:
             session_id=normalized.session_id,
             stream=stream_req,
             verbose=verbose,
+            stateful=stateful_http_bridge_enabled,
+            explicit_previous_response_id=getattr(
+                prepared,
+                "explicit_previous_response_id",
+                False,
+            ),
         )
 
     upstream, error_resp = start_upstream_raw_request(

--- a/chatmock/routes_openai.py
+++ b/chatmock/routes_openai.py
@@ -673,6 +673,9 @@ def responses_create() -> Response:
                 "explicit_previous_response_id",
                 False,
             ),
+            max_retained_sessions=current_app.config.get(
+                "RESPONSES_WEBSOCKET_UPSTREAM_MAX_RETAINED_SESSIONS"
+            ),
         )
 
     upstream, error_resp = start_upstream_raw_request(

--- a/chatmock/routes_openai.py
+++ b/chatmock/routes_openai.py
@@ -43,9 +43,32 @@ from .utils import (
 
 openai_bp = Blueprint("openai", __name__)
 
-# HTTP /v1/responses stays transport-only. Only the frontend websocket route
-# opts into previous_response_id reuse semantics through session.py.
-HTTP_RESPONSES_ALLOW_PREVIOUS_RESPONSE_ID = False
+
+def _stateful_http_responses_bridge_enabled() -> bool:
+    # Ordinary HTTP and the one-shot bridge stay stateless. The opt-in stateful
+    # bridge is the only HTTP branch that enables previous_response_id reuse.
+    return bool(current_app.config.get("RESPONSES_WEBSOCKET_UPSTREAM")) and bool(
+        current_app.config.get("RESPONSES_WEBSOCKET_UPSTREAM_STATEFUL")
+    )
+
+
+def _error_json_response(message: str, status_code: int) -> Response:
+    resp = make_response(jsonify({"error": {"message": message}}), status_code)
+    for k, v in build_cors_headers().items():
+        resp.headers.setdefault(k, v)
+    return resp
+
+
+def _require_explicit_stateful_http_session_id() -> tuple[str | None, Response | None]:
+    client_session_id = extract_client_session_id(request.headers)
+    if isinstance(client_session_id, str):
+        client_session_id = client_session_id.strip()
+    if client_session_id:
+        return client_session_id, None
+    return None, _error_json_response(
+        "Stateful HTTP websocket bridge mode requires a non-empty X-Session-Id or session_id header.",
+        400,
+    )
 
 
 def _log_json(prefix: str, payload: Any) -> None:
@@ -579,6 +602,7 @@ def completions() -> Response:
 @openai_bp.route("/v1/responses", methods=["POST"])
 def responses_create() -> Response:
     verbose = bool(current_app.config.get("VERBOSE"))
+    stateful_http_bridge_enabled = _stateful_http_responses_bridge_enabled()
     raw = request.get_data(cache=True, as_text=True) or ""
     if verbose:
         try:
@@ -600,11 +624,22 @@ def responses_create() -> Response:
             _log_json("OUT POST /v1/responses", err)
         return jsonify(err), 400
 
+    client_session_id = extract_client_session_id(request.headers)
+    if stateful_http_bridge_enabled:
+        client_session_id, error_resp = _require_explicit_stateful_http_session_id()
+        if error_resp is not None:
+            if verbose:
+                _log_json(
+                    "OUT POST /v1/responses",
+                    {"error": {"message": error_resp.get_json()["error"]["message"]}},
+                )
+            return error_resp
+
     try:
         normalized = normalize_responses_payload(
             payload,
             config=current_app.config,
-            client_session_id=extract_client_session_id(request.headers),
+            client_session_id=client_session_id,
         )
     except ResponsesRequestError as exc:
         err: Dict[str, Any] = {"error": {"message": str(exc)}}
@@ -620,7 +655,7 @@ def responses_create() -> Response:
     prepared = prepare_responses_request_for_session(
         normalized.session_id,
         normalized.payload,
-        allow_previous_response_id=HTTP_RESPONSES_ALLOW_PREVIOUS_RESPONSE_ID,
+        allow_previous_response_id=stateful_http_bridge_enabled,
     )
     stream_req = bool(prepared.payload.get("stream", False))
     upstream_request_payload = dict(prepared.payload)

--- a/chatmock/routes_openai.py
+++ b/chatmock/routes_openai.py
@@ -621,6 +621,14 @@ def responses_create() -> Response:
     stream_req = bool(prepared.payload.get("stream", False))
     upstream_payload = dict(prepared.payload)
     upstream_payload["stream"] = True
+    if bool(current_app.config.get("RESPONSES_WEBSOCKET_UPSTREAM")):
+        return responses_websocket_bridge.send_responses_request_via_websocket(
+            payload=upstream_payload,
+            session_id=normalized.session_id,
+            stream=stream_req,
+            verbose=verbose,
+        )
+
     upstream, error_resp = start_upstream_raw_request(
         upstream_payload,
         session_id=normalized.session_id,

--- a/chatmock/routes_openai.py
+++ b/chatmock/routes_openai.py
@@ -631,9 +631,10 @@ def responses_create() -> Response:
     if normalized.service_tier_resolution.warning_message and verbose:
         print(f"[FastMode] {normalized.service_tier_resolution.warning_message}")
 
+    previous_response_id = normalized.payload.get("previous_response_id")
     explicit_previous_response_id = (
-        isinstance(normalized.payload.get("previous_response_id"), str)
-        and bool(normalized.payload.get("previous_response_id").strip())
+        isinstance(previous_response_id, str)
+        and bool(previous_response_id.strip())
     )
     if stateful_http_bridge_enabled:
         prepared_payload = dict(normalized.payload)

--- a/chatmock/session.py
+++ b/chatmock/session.py
@@ -29,6 +29,7 @@ class _ResponsesSessionState:
     last_request_payload: Dict[str, Any] | None = None
     last_response_id: str | None = None
     last_response_items: List[Dict[str, Any]] = field(default_factory=list)
+    last_authoritative_empty_response_items: List[Dict[str, Any]] = field(default_factory=list)
     inflight_request_payload: Dict[str, Any] | None = None
     inflight_track_result: bool = False
     inflight_response_id: str | None = None
@@ -134,6 +135,7 @@ def _clear_reuse_state(state: _ResponsesSessionState) -> None:
     state.last_request_payload = None
     state.last_response_id = None
     state.last_response_items = []
+    state.last_authoritative_empty_response_items = []
     state.inflight_request_payload = None
     state.inflight_track_result = False
     state.inflight_response_id = None
@@ -145,6 +147,21 @@ def _clear_inflight(state: _ResponsesSessionState) -> None:
     state.inflight_track_result = False
     state.inflight_response_id = None
     state.inflight_response_items = []
+
+
+def _resolve_response_output_items(
+    response: Dict[str, Any] | None,
+    inflight_items: List[Dict[str, Any]],
+) -> tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    output_items: List[Dict[str, Any]] = copy.deepcopy(inflight_items)
+    authoritative_empty_items: List[Dict[str, Any]] = []
+    if isinstance(response, dict) and "output" in response:
+        output = response.get("output")
+        if isinstance(output, list):
+            output_items = [copy.deepcopy(item) for item in output if isinstance(item, dict)]
+            if not output_items:
+                authoritative_empty_items = _conversation_output_items(copy.deepcopy(inflight_items))
+    return output_items, authoritative_empty_items
 
 
 def ensure_session_id(
@@ -209,8 +226,14 @@ def prepare_responses_request_for_session(
             baseline.extend(copy.deepcopy(state.last_response_items))
             baseline_len = len(baseline)
             if request_input[:baseline_len] == baseline and baseline_len <= len(request_input):
-                outbound_payload["input"] = copy.deepcopy(request_input[baseline_len:])
-                outbound_payload["previous_response_id"] = state.last_response_id
+                remaining_input = copy.deepcopy(request_input[baseline_len:])
+                authoritative_empty_items = state.last_authoritative_empty_response_items
+                if not (
+                    authoritative_empty_items
+                    and remaining_input[: len(authoritative_empty_items)] == authoritative_empty_items
+                ):
+                    outbound_payload["input"] = remaining_input
+                    outbound_payload["previous_response_id"] = state.last_response_id
 
         state.inflight_request_payload = full_payload
         state.inflight_track_result = True
@@ -252,12 +275,14 @@ def note_responses_stream_event(session_id: str, event: Dict[str, Any]) -> None:
             response = event.get("response")
             response_id = None
             response_items: List[Dict[str, Any]] = copy.deepcopy(state.inflight_response_items)
+            authoritative_empty_items: List[Dict[str, Any]] = []
             if isinstance(response, dict):
                 if isinstance(response.get("id"), str):
                     response_id = response.get("id")
-                output = response.get("output")
-                if isinstance(output, list) and output:
-                    response_items = [copy.deepcopy(item) for item in output if isinstance(item, dict)]
+                response_items, authoritative_empty_items = _resolve_response_output_items(
+                    response,
+                    state.inflight_response_items,
+                )
             if not response_id:
                 response_id = state.inflight_response_id
 
@@ -265,10 +290,12 @@ def note_responses_stream_event(session_id: str, event: Dict[str, Any]) -> None:
                 state.last_request_payload = copy.deepcopy(state.inflight_request_payload)
                 state.last_response_id = response_id
                 state.last_response_items = _conversation_output_items(response_items)
+                state.last_authoritative_empty_response_items = authoritative_empty_items
             else:
                 state.last_request_payload = None
                 state.last_response_id = None
                 state.last_response_items = []
+                state.last_authoritative_empty_response_items = []
             _clear_inflight(state)
             return
 
@@ -290,18 +317,20 @@ def note_responses_final_response(session_id: str, response_obj: Dict[str, Any])
         response_id = response_obj.get("id") if isinstance(response_obj.get("id"), str) else None
         if not response_id:
             response_id = state.inflight_response_id
-        output = response_obj.get("output")
-        output_items: List[Dict[str, Any]] = copy.deepcopy(state.inflight_response_items)
-        if isinstance(output, list) and output:
-            output_items = [copy.deepcopy(item) for item in output if isinstance(item, dict)]
+        output_items, authoritative_empty_items = _resolve_response_output_items(
+            response_obj,
+            state.inflight_response_items,
+        )
         if state.inflight_track_result and state.inflight_request_payload is not None and response_id:
             state.last_request_payload = copy.deepcopy(state.inflight_request_payload)
             state.last_response_id = response_id
             state.last_response_items = _conversation_output_items(output_items)
+            state.last_authoritative_empty_response_items = authoritative_empty_items
         else:
             state.last_request_payload = None
             state.last_response_id = None
             state.last_response_items = []
+            state.last_authoritative_empty_response_items = []
         _clear_inflight(state)
 
 

--- a/chatmock/session.py
+++ b/chatmock/session.py
@@ -21,6 +21,7 @@ _RESPONSES_ORDER: List[str] = []
 class PreparedResponsesRequest:
     payload: Dict[str, Any]
     session_id: str
+    explicit_previous_response_id: bool = False
 
 
 @dataclass
@@ -186,6 +187,7 @@ def prepare_responses_request_for_session(
                 return PreparedResponsesRequest(
                     payload=outbound_payload,
                     session_id=session_id,
+                    explicit_previous_response_id=True,
                 )
 
             full_payload.pop("previous_response_id", None)
@@ -218,6 +220,7 @@ def prepare_responses_request_for_session(
     return PreparedResponsesRequest(
         payload=outbound_payload,
         session_id=session_id,
+        explicit_previous_response_id=False,
     )
 
 

--- a/chatmock/session.py
+++ b/chatmock/session.py
@@ -281,8 +281,12 @@ def note_responses_final_response(session_id: str, response_obj: Dict[str, Any])
             return
 
         response_id = response_obj.get("id") if isinstance(response_obj.get("id"), str) else None
+        if not response_id:
+            response_id = state.inflight_response_id
         output = response_obj.get("output")
-        output_items = [copy.deepcopy(item) for item in output if isinstance(item, dict)] if isinstance(output, list) else []
+        output_items: List[Dict[str, Any]] = copy.deepcopy(state.inflight_response_items)
+        if isinstance(output, list) and output:
+            output_items = [copy.deepcopy(item) for item in output if isinstance(item, dict)]
         if state.inflight_track_result and state.inflight_request_payload is not None and response_id:
             state.last_request_payload = copy.deepcopy(state.inflight_request_payload)
             state.last_response_id = response_id

--- a/chatmock/session.py
+++ b/chatmock/session.py
@@ -182,10 +182,14 @@ def prepare_responses_request_for_session(
 
         if explicit_previous_response_id:
             _clear_reuse_state(state)
-            return PreparedResponsesRequest(
-                payload=outbound_payload,
-                session_id=session_id,
-            )
+            if allow_previous_response_id:
+                return PreparedResponsesRequest(
+                    payload=outbound_payload,
+                    session_id=session_id,
+                )
+
+            full_payload.pop("previous_response_id", None)
+            outbound_payload.pop("previous_response_id", None)
 
         request_input = _input_list(full_payload)
         if (

--- a/chatmock/upstream.py
+++ b/chatmock/upstream.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
 import json
+import os
+import ssl
 import time
 from typing import Any, Dict, List, Tuple
 from urllib.parse import urlparse, urlunparse
 
+import certifi
 import requests
 from flask import Response, current_app, jsonify, make_response
+from websockets.sync.client import connect as websocket_connect
 
 from .config import CHATGPT_RESPONSES_URL
 from .http import build_cors_headers
@@ -179,3 +183,21 @@ def build_upstream_websocket_url() -> str:
     elif scheme == "http":
         parsed = parsed._replace(scheme="ws")
     return urlunparse(parsed)
+
+
+def build_upstream_websocket_ssl_context() -> ssl.SSLContext:
+    cafile = (
+        os.getenv("CODEX_CA_CERTIFICATE")
+        or os.getenv("SSL_CERT_FILE")
+        or certifi.where()
+    )
+    return ssl.create_default_context(cafile=cafile)
+
+
+def connect_upstream_websocket(url: str, headers: Dict[str, str]):
+    return websocket_connect(
+        url,
+        additional_headers=headers,
+        open_timeout=15,
+        ssl=build_upstream_websocket_ssl_context(),
+    )

--- a/chatmock/websocket_routes.py
+++ b/chatmock/websocket_routes.py
@@ -1,14 +1,10 @@
 from __future__ import annotations
 
 import json
-import os
-import ssl
 from typing import Any, Dict
 
-import certifi
 from flask import current_app, request
 from flask_sock import Sock
-from websockets.sync.client import connect as websocket_connect
 from websockets.exceptions import ConnectionClosed
 
 from .responses_api import (
@@ -21,7 +17,7 @@ from .session import (
     note_responses_stream_event,
     prepare_responses_request_for_session,
 )
-from .upstream import build_upstream_headers, build_upstream_websocket_url
+from .upstream import build_upstream_headers, build_upstream_websocket_url, connect_upstream_websocket
 from .utils import get_effective_chatgpt_auth
 
 
@@ -47,24 +43,6 @@ def _is_terminal_event(event: Any) -> bool:
         return False
     kind = event.get("type")
     return kind in ("response.completed", "response.failed", "error")
-
-
-def _build_websocket_ssl_context() -> ssl.SSLContext:
-    cafile = (
-        os.getenv("CODEX_CA_CERTIFICATE")
-        or os.getenv("SSL_CERT_FILE")
-        or certifi.where()
-    )
-    return ssl.create_default_context(cafile=cafile)
-
-
-def connect_upstream_websocket(url: str, headers: Dict[str, str]):
-    return websocket_connect(
-        url,
-        additional_headers=headers,
-        open_timeout=15,
-        ssl=_build_websocket_ssl_context(),
-    )
 
 
 def register_websocket_routes(sock: Sock) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -48,3 +48,42 @@ class CLIServeFlagTests(unittest.TestCase):
                     env={"CHATGPT_LOCAL_RESPONSES_WEBSOCKET_UPSTREAM": env_value},
                 )
                 self.assertFalse(kwargs["responses_websocket_upstream"])
+
+    def test_serve_defaults_responses_websocket_upstream_stateful_disabled(self) -> None:
+        kwargs = self._run_main(["chatmock", "serve"])
+        self.assertFalse(kwargs["responses_websocket_upstream_stateful"])
+
+    def test_serve_can_enable_responses_websocket_upstream_stateful(self) -> None:
+        kwargs = self._run_main(
+            [
+                "chatmock",
+                "serve",
+                "--responses-websocket-upstream",
+                "--responses-websocket-upstream-stateful",
+            ]
+        )
+        self.assertTrue(kwargs["responses_websocket_upstream"])
+        self.assertTrue(kwargs["responses_websocket_upstream_stateful"])
+
+    def test_serve_can_explicitly_disable_responses_websocket_upstream_stateful(self) -> None:
+        kwargs = self._run_main(
+            ["chatmock", "serve", "--no-responses-websocket-upstream-stateful"],
+            env={"CHATGPT_LOCAL_RESPONSES_WEBSOCKET_UPSTREAM_STATEFUL": "true"},
+        )
+        self.assertFalse(kwargs["responses_websocket_upstream_stateful"])
+
+    def test_serve_uses_env_to_enable_responses_websocket_upstream_stateful(self) -> None:
+        kwargs = self._run_main(
+            ["chatmock", "serve"],
+            env={"CHATGPT_LOCAL_RESPONSES_WEBSOCKET_UPSTREAM_STATEFUL": "yes"},
+        )
+        self.assertTrue(kwargs["responses_websocket_upstream_stateful"])
+
+    def test_serve_env_falsey_values_do_not_enable_responses_websocket_upstream_stateful(self) -> None:
+        for env_value in ("false", "0"):
+            with self.subTest(env_value=env_value):
+                kwargs = self._run_main(
+                    ["chatmock", "serve"],
+                    env={"CHATGPT_LOCAL_RESPONSES_WEBSOCKET_UPSTREAM_STATEFUL": env_value},
+                )
+                self.assertFalse(kwargs["responses_websocket_upstream_stateful"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+from chatmock import cli
+
+
+class CLIServeFlagTests(unittest.TestCase):
+    def _run_main(self, argv: list[str], *, env: dict[str, str] | None = None) -> dict[str, object]:
+        with patch.dict(os.environ, env or {}, clear=True):
+            with patch.object(sys, "argv", argv):
+                with patch("chatmock.cli.cmd_serve", return_value=0) as mock_cmd_serve:
+                    with self.assertRaises(SystemExit) as exit_info:
+                        cli.main()
+        self.assertEqual(exit_info.exception.code, 0)
+        return mock_cmd_serve.call_args.kwargs
+
+    def test_serve_defaults_responses_websocket_upstream_disabled(self) -> None:
+        kwargs = self._run_main(["chatmock", "serve"])
+        self.assertFalse(kwargs["responses_websocket_upstream"])
+
+    def test_serve_can_enable_responses_websocket_upstream(self) -> None:
+        kwargs = self._run_main(["chatmock", "serve", "--responses-websocket-upstream"])
+        self.assertTrue(kwargs["responses_websocket_upstream"])
+
+    def test_serve_can_explicitly_disable_responses_websocket_upstream(self) -> None:
+        kwargs = self._run_main(
+            ["chatmock", "serve", "--no-responses-websocket-upstream"],
+            env={"CHATGPT_LOCAL_RESPONSES_WEBSOCKET_UPSTREAM": "true"},
+        )
+        self.assertFalse(kwargs["responses_websocket_upstream"])
+
+    def test_serve_uses_env_to_enable_responses_websocket_upstream(self) -> None:
+        kwargs = self._run_main(
+            ["chatmock", "serve"],
+            env={"CHATGPT_LOCAL_RESPONSES_WEBSOCKET_UPSTREAM": "yes"},
+        )
+        self.assertTrue(kwargs["responses_websocket_upstream"])
+
+    def test_serve_env_falsey_values_do_not_enable_responses_websocket_upstream(self) -> None:
+        for env_value in ("false", "0"):
+            with self.subTest(env_value=env_value):
+                kwargs = self._run_main(
+                    ["chatmock", "serve"],
+                    env={"CHATGPT_LOCAL_RESPONSES_WEBSOCKET_UPSTREAM": env_value},
+                )
+                self.assertFalse(kwargs["responses_websocket_upstream"])

--- a/tests/test_responses_websocket_sessions.py
+++ b/tests/test_responses_websocket_sessions.py
@@ -5,6 +5,7 @@ import unittest
 from chatmock.responses_websocket_sessions import (
     ResponsesWebsocketSessionCapacityError,
     ResponsesWebsocketSessionConflictError,
+    ResponsesWebsocketSessionNotFoundError,
     acquire_retained_upstream_websocket,
     release_retained_upstream_websocket,
     reset_retained_upstream_websocket_sessions,
@@ -29,7 +30,7 @@ class RetainedUpstreamWebsocketRegistryTests(unittest.TestCase):
     def tearDown(self) -> None:
         reset_retained_upstream_websocket_sessions()
 
-    def test_registry_reuses_released_websocket_for_same_session(self) -> None:
+    def test_registry_promotes_first_turn_to_response_marker_and_reuses_it(self) -> None:
         created: list[FakeRetainedUpstreamWebsocket] = []
 
         def factory() -> FakeRetainedUpstreamWebsocket:
@@ -37,20 +38,69 @@ class RetainedUpstreamWebsocketRegistryTests(unittest.TestCase):
             created.append(websocket)
             return websocket
 
-        first = acquire_retained_upstream_websocket("session-fixed", factory, max_sessions=2)
-        release_retained_upstream_websocket(first, retain=True)
-        second = acquire_retained_upstream_websocket("session-fixed", factory, max_sessions=2)
+        first = acquire_retained_upstream_websocket(None, factory, max_sessions=2)
+        release_retained_upstream_websocket(
+            first,
+            retain=True,
+            response_id="resp_fixed_1",
+        )
+        second = acquire_retained_upstream_websocket("resp_fixed_1", factory, max_sessions=2)
 
         self.assertTrue(first.created)
         self.assertFalse(second.created)
         self.assertIs(first.upstream_ws, second.upstream_ws)
         self.assertEqual(len(created), 1)
 
-        release_retained_upstream_websocket(second, retain=True)
+        release_retained_upstream_websocket(
+            second,
+            retain=True,
+            response_id="resp_fixed_2",
+        )
 
-    def test_registry_rejects_same_session_contention(self) -> None:
+    def test_registry_rotates_retained_ownership_to_latest_response_marker(self) -> None:
+        first = acquire_retained_upstream_websocket(None, FakeRetainedUpstreamWebsocket, max_sessions=2)
+        release_retained_upstream_websocket(
+            first,
+            retain=True,
+            response_id="resp_fixed_1",
+        )
+
+        second = acquire_retained_upstream_websocket(
+            "resp_fixed_1",
+            FakeRetainedUpstreamWebsocket,
+            max_sessions=2,
+        )
+        release_retained_upstream_websocket(
+            second,
+            retain=True,
+            response_id="resp_fixed_2",
+        )
+
+        third = acquire_retained_upstream_websocket(
+            "resp_fixed_2",
+            FakeRetainedUpstreamWebsocket,
+            max_sessions=2,
+        )
+
+        self.assertFalse(third.created)
+        self.assertIs(third.upstream_ws, first.upstream_ws)
+
+        release_retained_upstream_websocket(
+            third,
+            retain=True,
+            response_id="resp_fixed_3",
+        )
+
+    def test_registry_rejects_same_marker_contention(self) -> None:
+        seed = acquire_retained_upstream_websocket(None, FakeRetainedUpstreamWebsocket, max_sessions=2)
+        release_retained_upstream_websocket(
+            seed,
+            retain=True,
+            response_id="resp_fixed_1",
+        )
+
         lease = acquire_retained_upstream_websocket(
-            "session-fixed",
+            "resp_fixed_1",
             FakeRetainedUpstreamWebsocket,
             max_sessions=2,
         )
@@ -60,41 +110,45 @@ class RetainedUpstreamWebsocketRegistryTests(unittest.TestCase):
             "already in progress",
         ):
             acquire_retained_upstream_websocket(
-                "session-fixed",
+                "resp_fixed_1",
                 FakeRetainedUpstreamWebsocket,
                 max_sessions=2,
             )
 
-        release_retained_upstream_websocket(lease, retain=True)
+        release_retained_upstream_websocket(
+            lease,
+            retain=True,
+            response_id="resp_fixed_2",
+        )
 
-    def test_registry_rejects_new_session_when_all_capacity_is_in_use(self) -> None:
-        first = acquire_retained_upstream_websocket("session-1", FakeRetainedUpstreamWebsocket, max_sessions=2)
-        second = acquire_retained_upstream_websocket("session-2", FakeRetainedUpstreamWebsocket, max_sessions=2)
+    def test_registry_rejects_new_conversation_when_all_capacity_is_in_use(self) -> None:
+        first = acquire_retained_upstream_websocket(None, FakeRetainedUpstreamWebsocket, max_sessions=2)
+        second = acquire_retained_upstream_websocket(None, FakeRetainedUpstreamWebsocket, max_sessions=2)
 
         with self.assertRaisesRegex(
             ResponsesWebsocketSessionCapacityError,
             "Too many retained upstream websocket sessions are active right now.",
         ):
-            acquire_retained_upstream_websocket("session-3", FakeRetainedUpstreamWebsocket, max_sessions=2)
+            acquire_retained_upstream_websocket(None, FakeRetainedUpstreamWebsocket, max_sessions=2)
 
         release_retained_upstream_websocket(first, retain=False)
         release_retained_upstream_websocket(second, retain=False)
 
-    def test_registry_evicts_oldest_idle_session_when_capacity_is_reached(self) -> None:
-        first = acquire_retained_upstream_websocket("session-1", FakeRetainedUpstreamWebsocket, max_sessions=2)
-        release_retained_upstream_websocket(first, retain=True)
-        second = acquire_retained_upstream_websocket("session-2", FakeRetainedUpstreamWebsocket, max_sessions=2)
-        release_retained_upstream_websocket(second, retain=True)
+    def test_registry_evicts_oldest_idle_marker_when_capacity_is_reached(self) -> None:
+        first = acquire_retained_upstream_websocket(None, FakeRetainedUpstreamWebsocket, max_sessions=2)
+        release_retained_upstream_websocket(first, retain=True, response_id="resp_1")
+        second = acquire_retained_upstream_websocket(None, FakeRetainedUpstreamWebsocket, max_sessions=2)
+        release_retained_upstream_websocket(second, retain=True, response_id="resp_2")
 
-        third = acquire_retained_upstream_websocket("session-3", FakeRetainedUpstreamWebsocket, max_sessions=2)
+        third = acquire_retained_upstream_websocket(None, FakeRetainedUpstreamWebsocket, max_sessions=2)
 
         self.assertTrue(third.created)
         self.assertEqual(first.upstream_ws.close_calls, 1)
         self.assertEqual(second.upstream_ws.close_calls, 0)
 
-        release_retained_upstream_websocket(third, retain=True)
+        release_retained_upstream_websocket(third, retain=True, response_id="resp_3")
 
-    def test_registry_discards_closed_retained_websocket_before_reuse(self) -> None:
+    def test_registry_treats_closed_retained_websocket_as_missing_marker(self) -> None:
         created: list[FakeRetainedUpstreamWebsocket] = []
 
         def factory() -> FakeRetainedUpstreamWebsocket:
@@ -102,18 +156,22 @@ class RetainedUpstreamWebsocketRegistryTests(unittest.TestCase):
             created.append(websocket)
             return websocket
 
-        first = acquire_retained_upstream_websocket("session-fixed", factory, max_sessions=2)
-        release_retained_upstream_websocket(first, retain=True)
+        first = acquire_retained_upstream_websocket(None, factory, max_sessions=2)
+        release_retained_upstream_websocket(
+            first,
+            retain=True,
+            response_id="resp_fixed_1",
+        )
         first.upstream_ws.closed = True
 
-        second = acquire_retained_upstream_websocket("session-fixed", factory, max_sessions=2)
+        with self.assertRaisesRegex(
+            ResponsesWebsocketSessionNotFoundError,
+            "No retained upstream websocket exists",
+        ):
+            acquire_retained_upstream_websocket("resp_fixed_1", factory, max_sessions=2)
 
-        self.assertTrue(second.created)
-        self.assertIsNot(first.upstream_ws, second.upstream_ws)
         self.assertEqual(first.upstream_ws.close_calls, 1)
-        self.assertEqual(len(created), 2)
-
-        release_retained_upstream_websocket(second, retain=True)
+        self.assertEqual(len(created), 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_responses_websocket_sessions.py
+++ b/tests/test_responses_websocket_sessions.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import unittest
+
+from chatmock.responses_websocket_sessions import (
+    ResponsesWebsocketSessionCapacityError,
+    ResponsesWebsocketSessionConflictError,
+    acquire_retained_upstream_websocket,
+    release_retained_upstream_websocket,
+    reset_retained_upstream_websocket_sessions,
+)
+
+
+class FakeRetainedUpstreamWebsocket:
+    def __init__(self) -> None:
+        self.closed = False
+        self.close_calls = 0
+
+    def close(self) -> None:
+        self.closed = True
+        self.close_calls += 1
+        return None
+
+
+class RetainedUpstreamWebsocketRegistryTests(unittest.TestCase):
+    def setUp(self) -> None:
+        reset_retained_upstream_websocket_sessions()
+
+    def tearDown(self) -> None:
+        reset_retained_upstream_websocket_sessions()
+
+    def test_registry_reuses_released_websocket_for_same_session(self) -> None:
+        created: list[FakeRetainedUpstreamWebsocket] = []
+
+        def factory() -> FakeRetainedUpstreamWebsocket:
+            websocket = FakeRetainedUpstreamWebsocket()
+            created.append(websocket)
+            return websocket
+
+        first = acquire_retained_upstream_websocket("session-fixed", factory, max_sessions=2)
+        release_retained_upstream_websocket(first, retain=True)
+        second = acquire_retained_upstream_websocket("session-fixed", factory, max_sessions=2)
+
+        self.assertTrue(first.created)
+        self.assertFalse(second.created)
+        self.assertIs(first.upstream_ws, second.upstream_ws)
+        self.assertEqual(len(created), 1)
+
+        release_retained_upstream_websocket(second, retain=True)
+
+    def test_registry_rejects_same_session_contention(self) -> None:
+        lease = acquire_retained_upstream_websocket(
+            "session-fixed",
+            FakeRetainedUpstreamWebsocket,
+            max_sessions=2,
+        )
+
+        with self.assertRaisesRegex(
+            ResponsesWebsocketSessionConflictError,
+            "already in progress",
+        ):
+            acquire_retained_upstream_websocket(
+                "session-fixed",
+                FakeRetainedUpstreamWebsocket,
+                max_sessions=2,
+            )
+
+        release_retained_upstream_websocket(lease, retain=True)
+
+    def test_registry_rejects_new_session_when_all_capacity_is_in_use(self) -> None:
+        first = acquire_retained_upstream_websocket("session-1", FakeRetainedUpstreamWebsocket, max_sessions=2)
+        second = acquire_retained_upstream_websocket("session-2", FakeRetainedUpstreamWebsocket, max_sessions=2)
+
+        with self.assertRaisesRegex(
+            ResponsesWebsocketSessionCapacityError,
+            "Too many retained upstream websocket sessions are active right now.",
+        ):
+            acquire_retained_upstream_websocket("session-3", FakeRetainedUpstreamWebsocket, max_sessions=2)
+
+        release_retained_upstream_websocket(first, retain=False)
+        release_retained_upstream_websocket(second, retain=False)
+
+    def test_registry_evicts_oldest_idle_session_when_capacity_is_reached(self) -> None:
+        first = acquire_retained_upstream_websocket("session-1", FakeRetainedUpstreamWebsocket, max_sessions=2)
+        release_retained_upstream_websocket(first, retain=True)
+        second = acquire_retained_upstream_websocket("session-2", FakeRetainedUpstreamWebsocket, max_sessions=2)
+        release_retained_upstream_websocket(second, retain=True)
+
+        third = acquire_retained_upstream_websocket("session-3", FakeRetainedUpstreamWebsocket, max_sessions=2)
+
+        self.assertTrue(third.created)
+        self.assertEqual(first.upstream_ws.close_calls, 1)
+        self.assertEqual(second.upstream_ws.close_calls, 0)
+
+        release_retained_upstream_websocket(third, retain=True)
+
+    def test_registry_discards_closed_retained_websocket_before_reuse(self) -> None:
+        created: list[FakeRetainedUpstreamWebsocket] = []
+
+        def factory() -> FakeRetainedUpstreamWebsocket:
+            websocket = FakeRetainedUpstreamWebsocket()
+            created.append(websocket)
+            return websocket
+
+        first = acquire_retained_upstream_websocket("session-fixed", factory, max_sessions=2)
+        release_retained_upstream_websocket(first, retain=True)
+        first.upstream_ws.closed = True
+
+        second = acquire_retained_upstream_websocket("session-fixed", factory, max_sessions=2)
+
+        self.assertTrue(second.created)
+        self.assertIsNot(first.upstream_ws, second.upstream_ws)
+        self.assertEqual(first.upstream_ws.close_calls, 1)
+        self.assertEqual(len(created), 2)
+
+        release_retained_upstream_websocket(second, retain=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_responses_websocket_sessions.py
+++ b/tests/test_responses_websocket_sessions.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import threading
 import unittest
+
+import chatmock.responses_websocket_sessions as responses_websocket_sessions
 
 from chatmock.responses_websocket_sessions import (
     ResponsesWebsocketSessionCapacityError,
@@ -133,6 +136,75 @@ class RetainedUpstreamWebsocketRegistryTests(unittest.TestCase):
 
         release_retained_upstream_websocket(first, retain=False)
         release_retained_upstream_websocket(second, retain=False)
+
+    def test_registry_connects_new_upstream_websocket_outside_lock(self) -> None:
+        observed_lock_states: list[bool] = []
+
+        def factory() -> FakeRetainedUpstreamWebsocket:
+            observed_lock_states.append(responses_websocket_sessions._LOCK.locked())
+            return FakeRetainedUpstreamWebsocket()
+
+        lease = acquire_retained_upstream_websocket(None, factory, max_sessions=1)
+
+        self.assertEqual(observed_lock_states, [False])
+
+        release_retained_upstream_websocket(lease, retain=False)
+
+    def test_registry_counts_pending_reservation_against_capacity(self) -> None:
+        entered_factory = threading.Event()
+        allow_factory_exit = threading.Event()
+        created_leases = []
+        thread_failures = []
+
+        def blocking_factory() -> FakeRetainedUpstreamWebsocket:
+            entered_factory.set()
+            if not allow_factory_exit.wait(timeout=1):
+                raise RuntimeError("timed out waiting to finish websocket connect")
+            return FakeRetainedUpstreamWebsocket()
+
+        def acquire_in_thread() -> None:
+            try:
+                created_leases.append(
+                    acquire_retained_upstream_websocket(None, blocking_factory, max_sessions=1)
+                )
+            except Exception as exc:
+                thread_failures.append(exc)
+
+        worker = threading.Thread(target=acquire_in_thread)
+        worker.start()
+        self.assertTrue(entered_factory.wait(timeout=1))
+
+        with self.assertRaisesRegex(
+            ResponsesWebsocketSessionCapacityError,
+            "Too many retained upstream websocket sessions are active right now.",
+        ):
+            acquire_retained_upstream_websocket(None, FakeRetainedUpstreamWebsocket, max_sessions=1)
+
+        allow_factory_exit.set()
+        worker.join(timeout=1)
+
+        self.assertFalse(worker.is_alive())
+        self.assertEqual(thread_failures, [])
+        self.assertEqual(len(created_leases), 1)
+
+        release_retained_upstream_websocket(created_leases[0], retain=False)
+
+    def test_registry_rolls_back_pending_reservation_when_connect_fails(self) -> None:
+        def failing_factory() -> FakeRetainedUpstreamWebsocket:
+            raise RuntimeError("connect failed")
+
+        with self.assertRaisesRegex(RuntimeError, "connect failed"):
+            acquire_retained_upstream_websocket(None, failing_factory, max_sessions=1)
+
+        self.assertEqual(responses_websocket_sessions._PENDING_ANONYMOUS_RESERVATIONS, {})
+        self.assertEqual(responses_websocket_sessions._ANONYMOUS_LEASES, {})
+        self.assertEqual(responses_websocket_sessions._SESSIONS, {})
+
+        lease = acquire_retained_upstream_websocket(None, FakeRetainedUpstreamWebsocket, max_sessions=1)
+
+        self.assertTrue(lease.created)
+
+        release_retained_upstream_websocket(lease, retain=False)
 
     def test_registry_evicts_oldest_idle_marker_when_capacity_is_reached(self) -> None:
         first = acquire_retained_upstream_websocket(None, FakeRetainedUpstreamWebsocket, max_sessions=2)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import json
 import socket
 import threading
@@ -7,8 +8,9 @@ import time
 import unittest
 from unittest.mock import patch
 
+from chatmock import responses_websocket_bridge
 from chatmock.app import create_app
-from chatmock.session import note_responses_final_response, reset_session_state
+from chatmock.session import reset_session_state
 from flask import Response
 from websockets.sync.client import connect as ws_connect
 
@@ -785,46 +787,65 @@ class ResponsesWebsocketUpstreamContractTests(unittest.TestCase):
     def test_enabled_mode_keeps_http_previous_response_id_disabled(self) -> None:
         app = create_app(responses_websocket_upstream=True)
         client = app.test_client()
-        bridge_calls: list[dict[str, object]] = []
-        bridge_bodies = [
-            {
-                "id": "resp_ws_1",
-                "object": "response",
-                "status": "completed",
-                "output": [
-                    {
-                        "type": "message",
-                        "role": "assistant",
-                        "id": "msg_1",
-                        "content": [{"type": "output_text", "text": "assistant output"}],
-                    }
-                ],
-            },
-            {
-                "id": "resp_ws_2",
-                "object": "response",
-                "status": "completed",
-                "output": [],
-            },
-        ]
+        class FakeUpstreamWebsocket:
+            def __init__(self, messages: list[str]) -> None:
+                self.sent: list[str] = []
+                self._messages = list(messages)
 
-        def bridge_side_effect(*, payload, session_id, stream, verbose=False):
-            body = bridge_bodies[len(bridge_calls)]
-            note_responses_final_response(session_id, body)
-            bridge_calls.append(
-                {
-                    "payload": payload,
-                    "session_id": session_id,
-                    "stream": stream,
-                    "verbose": verbose,
-                }
-            )
-            return make_json_response(body)
+            def send(self, message: str) -> None:
+                self.sent.append(message)
+
+            def recv(self) -> str:
+                return self._messages.pop(0)
+
+            def close(self) -> None:
+                return None
+
+        first_upstream = FakeUpstreamWebsocket(
+            [
+                json.dumps({"type": "response.created", "response": {"id": "resp_ws_1", "object": "response", "status": "in_progress"}}),
+                json.dumps(
+                    {
+                        "type": "response.completed",
+                        "response": {
+                            "id": "resp_ws_1",
+                            "object": "response",
+                            "status": "completed",
+                            "output": [
+                                {
+                                    "type": "message",
+                                    "role": "assistant",
+                                    "id": "msg_1",
+                                    "content": [{"type": "output_text", "text": "assistant output"}],
+                                }
+                            ],
+                        },
+                    }
+                ),
+            ]
+        )
+        second_upstream = FakeUpstreamWebsocket(
+            [
+                json.dumps({"type": "response.created", "response": {"id": "resp_ws_2", "object": "response", "status": "in_progress"}}),
+                json.dumps(
+                    {
+                        "type": "response.completed",
+                        "response": {
+                            "id": "resp_ws_2",
+                            "object": "response",
+                            "status": "completed",
+                            "output": [],
+                        },
+                    }
+                ),
+            ]
+        )
 
         with (
+            patch("chatmock.responses_websocket_bridge.get_effective_chatgpt_auth", return_value=("token", "acct")),
             patch(
-                "chatmock.routes_openai.responses_websocket_bridge.send_responses_request_via_websocket",
-                side_effect=bridge_side_effect,
+                "chatmock.responses_websocket_bridge.connect_upstream_websocket",
+                side_effect=[first_upstream, second_upstream],
             ),
             patch(
                 "chatmock.routes_openai.start_upstream_raw_request",
@@ -859,9 +880,7 @@ class ResponsesWebsocketUpstreamContractTests(unittest.TestCase):
 
         self.assertEqual(first.status_code, 200)
         self.assertEqual(second.status_code, 200)
-        self.assertEqual(len(bridge_calls), 2)
-        second_payload = bridge_calls[1]["payload"]
-        self.assertFalse(bridge_calls[1]["stream"])
+        second_payload = json.loads(second_upstream.sent[0])
         self.assertNotIn("previous_response_id", second_payload)
         self.assertEqual(
             second_payload["input"],
@@ -966,6 +985,105 @@ class ResponsesWebsocketUpstreamContractTests(unittest.TestCase):
         self.assertEqual(response.status_code, 502)
         self.assertEqual(body["error"]["message"], "Upstream websocket event payload was not a JSON object")
         mock_bridge.assert_called_once()
+
+
+class ResponsesWebsocketBridgeTests(unittest.TestCase):
+    def setUp(self) -> None:
+        reset_session_state()
+        self.app = create_app()
+
+    def test_encode_sse_event_avoids_python_312_only_f_string_form(self) -> None:
+        source = inspect.getsource(responses_websocket_bridge._encode_sse_event)
+        self.assertNotIn('return f"data: {json.dumps(', source)
+        self.assertEqual(
+            responses_websocket_bridge._encode_sse_event({"type": "response.completed", "response": {"id": "resp_ws_1"}}),
+            b'data: {"type":"response.completed","response":{"id":"resp_ws_1"}}\n\n',
+        )
+
+    def test_parse_upstream_websocket_event_rejects_non_object_payload(self) -> None:
+        with self.assertRaisesRegex(
+            responses_websocket_bridge.ResponsesWebsocketBridgeProtocolError,
+            "Upstream websocket event payload was not a JSON object",
+        ):
+            responses_websocket_bridge.parse_upstream_websocket_event("[]")
+
+    def test_parse_upstream_websocket_event_requires_response_object_for_completed(self) -> None:
+        with self.assertRaisesRegex(
+            responses_websocket_bridge.ResponsesWebsocketBridgeProtocolError,
+            "Upstream websocket response.completed event is missing a response object",
+        ):
+            responses_websocket_bridge.parse_upstream_websocket_event('{"type":"response.completed"}')
+
+    @patch("chatmock.responses_websocket_bridge.get_effective_chatgpt_auth", return_value=("token", "acct"))
+    @patch("chatmock.responses_websocket_bridge.connect_upstream_websocket")
+    @patch("chatmock.responses_websocket_bridge.note_responses_final_response")
+    def test_bridge_aggregates_completed_response_for_non_stream_http_clients(self, mock_note_final_response, mock_connect, _mock_auth) -> None:
+        class FakeUpstreamWebsocket:
+            def __init__(self) -> None:
+                self.sent: list[str] = []
+                self._messages = [
+                    json.dumps({"type": "response.created", "response": {"id": "resp_ws_1", "object": "response", "status": "in_progress"}}),
+                    json.dumps({"type": "response.completed", "response": {"id": "resp_ws_1", "object": "response", "status": "completed", "output": []}}),
+                ]
+
+            def send(self, message: str) -> None:
+                self.sent.append(message)
+
+            def recv(self) -> str:
+                return self._messages.pop(0)
+
+            def close(self) -> None:
+                return None
+
+        fake_upstream = FakeUpstreamWebsocket()
+        mock_connect.return_value = fake_upstream
+
+        with self.app.test_request_context("/v1/responses", method="POST"):
+            response = responses_websocket_bridge.send_responses_request_via_websocket(
+                payload={"type": "response.create", "model": "gpt-5.4", "stream": True},
+                session_id="session-fixed",
+                stream=False,
+            )
+
+        body = response.get_json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(body["id"], "resp_ws_1")
+        self.assertEqual(json.loads(fake_upstream.sent[0])["model"], "gpt-5.4")
+        mock_note_final_response.assert_called_once_with("session-fixed", body)
+
+    @patch("chatmock.responses_websocket_bridge.get_effective_chatgpt_auth", return_value=("token", "acct"))
+    @patch("chatmock.responses_websocket_bridge.connect_upstream_websocket")
+    def test_bridge_translates_upstream_events_to_sse_for_streaming_http_clients(self, mock_connect, _mock_auth) -> None:
+        class FakeUpstreamWebsocket:
+            def __init__(self) -> None:
+                self._messages = [
+                    json.dumps({"type": "response.created", "response": {"id": "resp_ws_1"}}),
+                    json.dumps({"type": "response.output_text.delta", "delta": "hello"}),
+                    json.dumps({"type": "response.completed", "response": {"id": "resp_ws_1", "output": []}}),
+                ]
+
+            def send(self, message: str) -> None:
+                return None
+
+            def recv(self) -> str:
+                return self._messages.pop(0)
+
+            def close(self) -> None:
+                return None
+
+        mock_connect.return_value = FakeUpstreamWebsocket()
+
+        with self.app.test_request_context("/v1/responses", method="POST"):
+            response = responses_websocket_bridge.send_responses_request_via_websocket(
+                payload={"type": "response.create", "model": "gpt-5.4", "stream": True},
+                session_id="session-fixed",
+                stream=True,
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.content_type.startswith("text/event-stream"))
+        self.assertIn("response.output_text.delta", response.get_data(as_text=True))
+        self.assertIn("data: [DONE]", response.get_data(as_text=True))
 
 
 if __name__ == "__main__":

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -5,6 +5,7 @@ import json
 import socket
 import threading
 import time
+from types import SimpleNamespace
 import unittest
 from unittest.mock import patch
 
@@ -804,6 +805,65 @@ class ResponsesWebsocketUpstreamContractTests(unittest.TestCase):
         self.assertTrue(mock_bridge.call_args.kwargs["payload"]["stream"])
         self.assertNotIn("previous_response_id", mock_bridge.call_args.kwargs["payload"])
 
+    def test_enabled_mode_keeps_route_level_previous_response_id_policy_disabled(self) -> None:
+        app = create_app(responses_websocket_upstream=True)
+        client = app.test_client()
+        prepared_payload = {
+            "model": "gpt-5.4",
+            "input": [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "hello"}],
+                }
+            ],
+            "instructions": "base instructions",
+            "reasoning": {"effort": "medium", "summary": "auto"},
+            "include": ["reasoning.encrypted_content"],
+            "store": False,
+            "prompt_cache_key": "session-fixed",
+        }
+
+        with (
+            patch(
+                "chatmock.routes_openai.prepare_responses_request_for_session",
+                return_value=SimpleNamespace(payload=prepared_payload, session_id="session-fixed"),
+            ) as mock_prepare,
+            patch(
+                "chatmock.routes_openai.responses_websocket_bridge.send_responses_request_via_websocket"
+            ) as mock_bridge,
+            patch(
+                "chatmock.routes_openai.start_upstream_raw_request",
+                side_effect=AssertionError(
+                    "HTTP upstream transport should not be used when websocket upstream mode is enabled"
+                ),
+            ),
+        ):
+            mock_bridge.return_value = make_json_response(
+                {
+                    "id": "resp_ws_nonstream",
+                    "object": "response",
+                    "status": "completed",
+                    "output": [],
+                }
+            )
+
+            response = client.post(
+                "/v1/responses",
+                json={
+                    "model": "gpt-5.4",
+                    "previous_response_id": "resp_client_supplied",
+                    "input": "hello",
+                },
+                headers={"X-Session-Id": "session-fixed"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        mock_prepare.assert_called_once()
+        self.assertEqual(mock_prepare.call_args.args[0], "session-fixed")
+        self.assertFalse(mock_prepare.call_args.kwargs["allow_previous_response_id"])
+        self.assertNotIn("previous_response_id", mock_bridge.call_args.kwargs["payload"])
+
     def test_enabled_mode_uses_websocket_bridge_for_streaming_requests(self) -> None:
         app = create_app(responses_websocket_upstream=True)
         client = app.test_client()
@@ -1135,6 +1195,7 @@ class ResponsesWebsocketBridgeTests(unittest.TestCase):
         class FakeUpstreamWebsocket:
             def __init__(self) -> None:
                 self.sent: list[str] = []
+                self.close_calls = 0
                 self._messages = [
                     json.dumps({"type": "response.created", "response": {"id": "resp_ws_1", "object": "response", "status": "in_progress"}}),
                     json.dumps({"type": "response.completed", "response": {"id": "resp_ws_1", "object": "response", "status": "completed", "output": []}}),
@@ -1147,6 +1208,7 @@ class ResponsesWebsocketBridgeTests(unittest.TestCase):
                 return self._messages.pop(0)
 
             def close(self) -> None:
+                self.close_calls += 1
                 return None
 
         fake_upstream = FakeUpstreamWebsocket()
@@ -1163,6 +1225,7 @@ class ResponsesWebsocketBridgeTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(body["id"], "resp_ws_1")
         self.assertEqual(json.loads(fake_upstream.sent[0])["model"], "gpt-5.4")
+        self.assertEqual(fake_upstream.close_calls, 1)
         mock_note_final_response.assert_called_once_with("session-fixed", body)
 
     @patch("chatmock.responses_websocket_bridge.get_effective_chatgpt_auth", return_value=("token", "acct"))
@@ -1170,6 +1233,7 @@ class ResponsesWebsocketBridgeTests(unittest.TestCase):
     def test_bridge_translates_upstream_events_to_sse_for_streaming_http_clients(self, mock_connect, _mock_auth) -> None:
         class FakeUpstreamWebsocket:
             def __init__(self) -> None:
+                self.close_calls = 0
                 self._messages = [
                     json.dumps({"type": "response.created", "response": {"id": "resp_ws_1"}}),
                     json.dumps({"type": "response.output_text.delta", "delta": "hello"}),
@@ -1183,9 +1247,11 @@ class ResponsesWebsocketBridgeTests(unittest.TestCase):
                 return self._messages.pop(0)
 
             def close(self) -> None:
+                self.close_calls += 1
                 return None
 
-        mock_connect.return_value = FakeUpstreamWebsocket()
+        fake_upstream = FakeUpstreamWebsocket()
+        mock_connect.return_value = fake_upstream
 
         with self.app.test_request_context("/v1/responses", method="POST"):
             response = responses_websocket_bridge.send_responses_request_via_websocket(
@@ -1198,6 +1264,7 @@ class ResponsesWebsocketBridgeTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.content_type.startswith("text/event-stream"))
         self.assertIn("response.output_text.delta", body)
+        self.assertEqual(fake_upstream.close_calls, 1)
         self.assertIn('data: {"type":"response.completed","response":{"id":"resp_ws_1","output":[]}}', body)
         self.assertNotIn("data: [DONE]", body)
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 from chatmock import responses_websocket_bridge
 from chatmock.app import create_app
 from chatmock.responses_api import normalize_responses_payload
+from chatmock.responses_websocket_sessions import reset_retained_upstream_websocket_sessions
 from chatmock.session import reset_session_state
 from flask import Response
 from websockets.sync.client import connect as ws_connect
@@ -1124,9 +1125,13 @@ class ResponsesWebsocketUpstreamContractTests(unittest.TestCase):
 class ResponsesWebsocketUpstreamStatefulContractTests(unittest.TestCase):
     def setUp(self) -> None:
         reset_session_state()
+        reset_retained_upstream_websocket_sessions()
         self.app = create_app(responses_websocket_upstream=True)
         self.app.config["RESPONSES_WEBSOCKET_UPSTREAM_STATEFUL"] = True
         self.client = self.app.test_client()
+
+    def tearDown(self) -> None:
+        reset_retained_upstream_websocket_sessions()
 
     def test_stateful_mode_enables_route_level_previous_response_id_policy(self) -> None:
         prepared_payload = {
@@ -1628,7 +1633,11 @@ class ResponsesWebsocketUpstreamStatefulContractTests(unittest.TestCase):
 class ResponsesWebsocketBridgeTests(unittest.TestCase):
     def setUp(self) -> None:
         reset_session_state()
+        reset_retained_upstream_websocket_sessions()
         self.app = create_app()
+
+    def tearDown(self) -> None:
+        reset_retained_upstream_websocket_sessions()
 
     def test_encode_sse_event_avoids_python_312_only_f_string_form(self) -> None:
         source = inspect.getsource(responses_websocket_bridge._encode_sse_event)
@@ -1823,6 +1832,179 @@ class ResponsesWebsocketBridgeTests(unittest.TestCase):
         self.assertIn('data: {"type":"response.created","response":{"id":"resp_ws_1"}}', body)
         self.assertIn('data: {"type":"error","status_code":502,"error":{"message":"Upstream websocket response.completed event is missing a response object"}}', body)
         self.assertNotIn("data: [DONE]", body)
+
+    @patch("chatmock.responses_websocket_bridge.get_effective_chatgpt_auth", return_value=("token", "acct"))
+    @patch("chatmock.responses_websocket_bridge.connect_upstream_websocket")
+    def test_stateful_bridge_returns_503_when_all_retained_sessions_are_in_use(self, mock_connect, _mock_auth) -> None:
+        first_request_started = threading.Event()
+        release_first_request = threading.Event()
+        first_response: dict[str, Response] = {}
+        thread_errors: list[BaseException] = []
+
+        class BlockingUpstreamWebsocket(FakeUpstreamWebsocket):
+            def __init__(self) -> None:
+                super().__init__(
+                    [
+                        json.dumps({"type": "response.created", "response": {"id": "resp_capacity_1"}}),
+                        json.dumps({"type": "response.completed", "response": {"id": "resp_capacity_1", "output": []}}),
+                    ]
+                )
+                self._blocked = False
+
+            def recv(self) -> str:
+                if not self._blocked:
+                    self._blocked = True
+                    first_request_started.set()
+                    if not release_first_request.wait(timeout=2):
+                        raise AssertionError("First stateful bridge request did not reach the blocking point")
+                return super().recv()
+
+        mock_connect.return_value = BlockingUpstreamWebsocket()
+
+        def send_first_request() -> None:
+            try:
+                with self.app.test_request_context("/v1/responses", method="POST"):
+                    first_response["response"] = responses_websocket_bridge.send_responses_request_via_websocket(
+                        payload={"type": "response.create", "model": "gpt-5.4", "stream": True},
+                        session_id="session-1",
+                        stream=False,
+                        stateful=True,
+                        max_retained_sessions=1,
+                    )
+            except BaseException as exc:  # pragma: no cover - assertion plumbing for the worker thread
+                thread_errors.append(exc)
+
+        first_thread = threading.Thread(target=send_first_request)
+        first_thread.start()
+        self.assertTrue(
+            first_request_started.wait(timeout=1),
+            "First stateful bridge request did not block before issuing the capacity request",
+        )
+
+        with self.app.test_request_context("/v1/responses", method="POST"):
+            second = responses_websocket_bridge.send_responses_request_via_websocket(
+                payload={"type": "response.create", "model": "gpt-5.4", "stream": True},
+                session_id="session-2",
+                stream=False,
+                stateful=True,
+                max_retained_sessions=1,
+            )
+
+        release_first_request.set()
+        first_thread.join(timeout=2)
+
+        if thread_errors:
+            raise thread_errors[0]
+
+        self.assertFalse(first_thread.is_alive(), "First stateful bridge request thread did not finish")
+        self.assertEqual(first_response["response"].status_code, 200)
+        self.assertEqual(second.status_code, 503)
+        self.assertEqual(
+            second.get_json()["error"]["message"],
+            "Too many retained upstream websocket sessions are active right now.",
+        )
+        self.assertEqual(mock_connect.call_count, 1)
+
+    @patch("chatmock.responses_websocket_bridge.get_effective_chatgpt_auth", return_value=("token", "acct"))
+    @patch("chatmock.responses_websocket_bridge.connect_upstream_websocket")
+    def test_stateful_bridge_request_send_failure_evicts_retained_socket(self, mock_connect, _mock_auth) -> None:
+        class FakeUpstreamWebsocket:
+            def __init__(self, response_id: str) -> None:
+                self.fail_send = False
+                self.sent: list[str] = []
+                self.close_calls = 0
+                self._messages = [
+                    json.dumps({"type": "response.created", "response": {"id": response_id, "object": "response", "status": "in_progress"}}),
+                    json.dumps({"type": "response.completed", "response": {"id": response_id, "object": "response", "status": "completed", "output": []}}),
+                ]
+
+            def send(self, message: str) -> None:
+                if self.fail_send:
+                    raise RuntimeError("boom send")
+                self.sent.append(message)
+
+            def recv(self) -> str:
+                return self._messages.pop(0)
+
+            def close(self) -> None:
+                self.close_calls += 1
+                return None
+
+        first_upstream = FakeUpstreamWebsocket("resp_ws_stateful_1")
+        second_upstream = FakeUpstreamWebsocket("resp_ws_stateful_2")
+        mock_connect.side_effect = [first_upstream, second_upstream]
+
+        with self.app.test_request_context("/v1/responses", method="POST"):
+            first = responses_websocket_bridge.send_responses_request_via_websocket(
+                payload={"type": "response.create", "model": "gpt-5.4", "stream": True},
+                session_id="session-fixed",
+                stream=False,
+                stateful=True,
+            )
+            first_upstream.fail_send = True
+            second = responses_websocket_bridge.send_responses_request_via_websocket(
+                payload={"type": "response.create", "model": "gpt-5.4", "stream": True},
+                session_id="session-fixed",
+                stream=False,
+                stateful=True,
+            )
+            third = responses_websocket_bridge.send_responses_request_via_websocket(
+                payload={"type": "response.create", "model": "gpt-5.4", "stream": True},
+                session_id="session-fixed",
+                stream=False,
+                stateful=True,
+            )
+
+        self.assertEqual(first.status_code, 200)
+        self.assertEqual(second.status_code, 502)
+        self.assertIn("request send failed", second.get_json()["error"]["message"])
+        self.assertEqual(third.status_code, 200)
+        self.assertEqual(mock_connect.call_count, 2)
+        self.assertEqual(first_upstream.close_calls, 1)
+
+    @patch("chatmock.responses_websocket_bridge.get_effective_chatgpt_auth", return_value=("token", "acct"))
+    @patch("chatmock.responses_websocket_bridge.connect_upstream_websocket")
+    def test_stateful_bridge_protocol_error_evicts_retained_socket(self, mock_connect, _mock_auth) -> None:
+        first_upstream = FakeUpstreamWebsocket(
+            [
+                json.dumps({"type": "response.created", "response": {"id": "resp_ws_stateful_1", "object": "response", "status": "in_progress"}}),
+                json.dumps({"type": "response.completed", "response": {"id": "resp_ws_stateful_1", "object": "response", "status": "completed", "output": []}}),
+                json.dumps({"type": "response.completed"}),
+            ]
+        )
+        second_upstream = FakeUpstreamWebsocket(
+            [
+                json.dumps({"type": "response.created", "response": {"id": "resp_ws_stateful_2", "object": "response", "status": "in_progress"}}),
+                json.dumps({"type": "response.completed", "response": {"id": "resp_ws_stateful_2", "object": "response", "status": "completed", "output": []}}),
+            ]
+        )
+        mock_connect.side_effect = [first_upstream, second_upstream]
+
+        with self.app.test_request_context("/v1/responses", method="POST"):
+            first = responses_websocket_bridge.send_responses_request_via_websocket(
+                payload={"type": "response.create", "model": "gpt-5.4", "stream": True},
+                session_id="session-fixed",
+                stream=False,
+                stateful=True,
+            )
+            second = responses_websocket_bridge.send_responses_request_via_websocket(
+                payload={"type": "response.create", "model": "gpt-5.4", "stream": True},
+                session_id="session-fixed",
+                stream=False,
+                stateful=True,
+            )
+            third = responses_websocket_bridge.send_responses_request_via_websocket(
+                payload={"type": "response.create", "model": "gpt-5.4", "stream": True},
+                session_id="session-fixed",
+                stream=False,
+                stateful=True,
+            )
+
+        self.assertEqual(first.status_code, 200)
+        self.assertEqual(second.status_code, 502)
+        self.assertEqual(third.status_code, 200)
+        self.assertEqual(mock_connect.call_count, 2)
+        self.assertEqual(first_upstream.close_calls, 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -16,7 +16,12 @@ from chatmock.responses_websocket_sessions import (
     RetainedUpstreamWebsocketLease,
     reset_retained_upstream_websocket_sessions,
 )
-from chatmock.session import reset_session_state
+from chatmock.session import (
+    note_responses_final_response,
+    note_responses_stream_event,
+    prepare_responses_request_for_session,
+    reset_session_state,
+)
 from flask import Response
 from websockets.sync.client import connect as ws_connect
 
@@ -119,6 +124,135 @@ class RouteTests(unittest.TestCase):
         self.assertIn("gpt-5.4", model_ids)
         self.assertIn("gpt-5.4-mini", model_ids)
         self.assertIn("gpt-5.3-codex-spark", model_ids)
+
+    def test_session_reuse_keeps_explicit_empty_output_authoritative_for_follow_up_reuse(self) -> None:
+        initial_payload = {
+            "model": "gpt-5.4",
+            "input": [
+                {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hello"}]},
+            ],
+        }
+        assistant_item = {
+            "type": "message",
+            "role": "assistant",
+            "id": "msg_contract_1",
+            "content": [{"type": "output_text", "text": "assistant output"}],
+        }
+        follow_up_payload = {
+            "model": "gpt-5.4",
+            "input": [
+                {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hello"}]},
+                assistant_item,
+                {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "second"}]},
+            ],
+        }
+
+        for label, record_response in (
+            (
+                "stream",
+                lambda: (
+                    note_responses_stream_event("session-contract", {"type": "response.created", "response": {"id": "resp_contract_1"}}),
+                    note_responses_stream_event(
+                        "session-contract",
+                        {"type": "response.output_item.done", "item": assistant_item},
+                    ),
+                    note_responses_stream_event(
+                        "session-contract",
+                        {"type": "response.completed", "response": {"id": "resp_contract_1", "output": []}},
+                    ),
+                ),
+            ),
+            (
+                "final",
+                lambda: (
+                    note_responses_stream_event("session-contract", {"type": "response.created", "response": {"id": "resp_contract_1"}}),
+                    note_responses_stream_event(
+                        "session-contract",
+                        {"type": "response.output_item.done", "item": assistant_item},
+                    ),
+                    note_responses_final_response(
+                        "session-contract",
+                        {"id": "resp_contract_1", "output": []},
+                    ),
+                ),
+            ),
+        ):
+            with self.subTest(path=label):
+                reset_session_state()
+                prepare_responses_request_for_session("session-contract", initial_payload)
+                record_response()
+
+                prepared = prepare_responses_request_for_session("session-contract", follow_up_payload)
+
+                self.assertNotIn("previous_response_id", prepared.payload)
+                self.assertEqual(prepared.payload["input"], follow_up_payload["input"])
+
+    def test_session_reuse_uses_inflight_items_when_completed_output_is_missing(self) -> None:
+        initial_payload = {
+            "model": "gpt-5.4",
+            "input": [
+                {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hello"}]},
+            ],
+        }
+        assistant_item = {
+            "type": "message",
+            "role": "assistant",
+            "id": "msg_contract_1",
+            "content": [{"type": "output_text", "text": "assistant output"}],
+        }
+        follow_up_payload = {
+            "model": "gpt-5.4",
+            "input": [
+                {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hello"}]},
+                assistant_item,
+                {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "second"}]},
+            ],
+        }
+
+        for label, record_response in (
+            (
+                "stream",
+                lambda: (
+                    note_responses_stream_event("session-contract", {"type": "response.created", "response": {"id": "resp_contract_1"}}),
+                    note_responses_stream_event(
+                        "session-contract",
+                        {"type": "response.output_item.done", "item": assistant_item},
+                    ),
+                    note_responses_stream_event(
+                        "session-contract",
+                        {"type": "response.completed", "response": {"id": "resp_contract_1"}},
+                    ),
+                ),
+            ),
+            (
+                "final",
+                lambda: (
+                    note_responses_stream_event("session-contract", {"type": "response.created", "response": {"id": "resp_contract_1"}}),
+                    note_responses_stream_event(
+                        "session-contract",
+                        {"type": "response.output_item.done", "item": assistant_item},
+                    ),
+                    note_responses_final_response(
+                        "session-contract",
+                        {"id": "resp_contract_1"},
+                    ),
+                ),
+            ),
+        ):
+            with self.subTest(path=label):
+                reset_session_state()
+                prepare_responses_request_for_session("session-contract", initial_payload)
+                record_response()
+
+                prepared = prepare_responses_request_for_session("session-contract", follow_up_payload)
+
+                self.assertEqual(prepared.payload["previous_response_id"], "resp_contract_1")
+                self.assertEqual(
+                    prepared.payload["input"],
+                    [
+                        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "second"}]},
+                    ],
+                )
 
     def test_ollama_tags_list(self) -> None:
         response = self.client.get("/api/tags")
@@ -538,7 +672,7 @@ class RouteTests(unittest.TestCase):
 
     @patch("chatmock.websocket_routes.get_effective_chatgpt_auth", return_value=("token", "acct"))
     @patch("chatmock.websocket_routes.connect_upstream_websocket")
-    def test_responses_websocket_keeps_explicit_empty_output_authoritative_for_follow_up_contract(self, mock_connect, _mock_auth) -> None:
+    def test_responses_websocket_respects_explicit_empty_output_without_backfilling_follow_up_contract(self, mock_connect, _mock_auth) -> None:
         class FakeUpstreamWebsocket:
             def __init__(self) -> None:
                 self.sent: list[str] = []
@@ -2252,17 +2386,7 @@ class ResponsesWebsocketBridgeTests(unittest.TestCase):
 
         body = response.get_json()
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            body["output"],
-            [
-                {
-                    "type": "message",
-                    "role": "assistant",
-                    "id": "msg_ws_1",
-                    "content": [{"type": "output_text", "text": "assistant output"}],
-                }
-            ],
-        )
+        self.assertEqual(body["output"], [])
         self.assertEqual(fake_upstream.close_calls, 1)
         mock_note_final_response.assert_called_once_with("session-fixed", body)
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -968,6 +968,107 @@ class ResponsesWebsocketUpstreamContractTests(unittest.TestCase):
         self.assertTrue(mock_bridge.call_args.kwargs["stream"])
         self.assertTrue(mock_bridge.call_args.kwargs["payload"]["stream"])
 
+    def test_enabled_mode_streaming_completed_event_backfills_output_after_visible_delta(self) -> None:
+        app = create_app(responses_websocket_upstream=True)
+        client = app.test_client()
+        fake_upstream = FakeUpstreamWebsocket(
+            [
+                json.dumps(
+                    {
+                        "type": "response.created",
+                        "response": {"id": "resp_stream_terminal", "object": "response", "status": "in_progress"},
+                    }
+                ),
+                json.dumps({"type": "response.output_text.delta", "delta": "hello"}),
+                json.dumps(
+                    {
+                        "type": "response.completed",
+                        "response": {
+                            "id": "resp_stream_terminal",
+                            "object": "response",
+                            "status": "completed",
+                        },
+                    }
+                ),
+            ]
+        )
+
+        with (
+            patch("chatmock.responses_websocket_bridge.get_effective_chatgpt_auth", return_value=("token", "acct")),
+            patch("chatmock.responses_websocket_bridge.connect_upstream_websocket", return_value=fake_upstream),
+            patch(
+                "chatmock.routes_openai.start_upstream_raw_request",
+                side_effect=AssertionError(
+                    "HTTP upstream transport should not be used when websocket upstream mode is enabled"
+                ),
+            ),
+        ):
+            response = client.post(
+                "/v1/responses",
+                json={"model": "gpt-5.4", "input": "hello", "stream": True},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.content_type.startswith("text/event-stream"))
+        events = [
+            json.loads(line.removeprefix("data: "))
+            for line in response.get_data(as_text=True).splitlines()
+            if line.startswith("data: ")
+        ]
+        self.assertEqual(
+            [event["type"] for event in events],
+            ["response.created", "response.output_text.delta", "response.completed"],
+        )
+        self.assertEqual(events[1]["delta"], "hello")
+        self.assertIn("output", events[2]["response"])
+        self.assertIsInstance(events[2]["response"]["output"], list)
+
+    def test_enabled_mode_non_stream_completed_response_backfills_output_after_delta_only_upstream(self) -> None:
+        app = create_app(responses_websocket_upstream=True)
+        client = app.test_client()
+        fake_upstream = FakeUpstreamWebsocket(
+            [
+                json.dumps(
+                    {
+                        "type": "response.created",
+                        "response": {"id": "resp_nonstream_terminal", "object": "response", "status": "in_progress"},
+                    }
+                ),
+                json.dumps({"type": "response.output_text.delta", "delta": "hello"}),
+                json.dumps(
+                    {
+                        "type": "response.completed",
+                        "response": {
+                            "id": "resp_nonstream_terminal",
+                            "object": "response",
+                            "status": "completed",
+                        },
+                    }
+                ),
+            ]
+        )
+
+        with (
+            patch("chatmock.responses_websocket_bridge.get_effective_chatgpt_auth", return_value=("token", "acct")),
+            patch("chatmock.responses_websocket_bridge.connect_upstream_websocket", return_value=fake_upstream),
+            patch(
+                "chatmock.routes_openai.start_upstream_raw_request",
+                side_effect=AssertionError(
+                    "HTTP upstream transport should not be used when websocket upstream mode is enabled"
+                ),
+            ),
+        ):
+            response = client.post(
+                "/v1/responses",
+                json={"model": "gpt-5.4", "input": "hello"},
+            )
+
+        body = response.get_json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(body["id"], "resp_nonstream_terminal")
+        self.assertIn("output", body)
+        self.assertIsInstance(body["output"], list)
+
     def test_enabled_mode_keeps_http_previous_response_id_disabled(self) -> None:
         app = create_app(responses_websocket_upstream=True)
         client = app.test_client()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1725,12 +1725,15 @@ class ResponsesWebsocketUpstreamStatefulContractTests(unittest.TestCase):
             first = self.client.post(
                 "/v1/responses",
                 json={"model": "gpt-5.4", "input": "hello"},
-                headers={"X-Session-Id": "session-fixed"},
             )
             second = self.client.post(
                 "/v1/responses",
-                json={"model": "gpt-5.4", "input": "second", "stream": True},
-                headers={"X-Session-Id": "session-fixed"},
+                json={
+                    "model": "gpt-5.4",
+                    "input": "second",
+                    "stream": True,
+                    "previous_response_id": "resp_stream_characterization_1",
+                },
             )
 
         self.assertEqual(first.status_code, 200)
@@ -1740,10 +1743,10 @@ class ResponsesWebsocketUpstreamStatefulContractTests(unittest.TestCase):
         self.assertIn('"code":"previous_response_not_found"', payload)
         self.assertIn('"status_code":400', payload)
 
-    def test_stateful_mode_applies_route_level_retained_session_capacity_limit(self) -> None:
+    def test_stateful_mode_applies_route_level_retained_session_capacity_limit_without_headers(self) -> None:
         first_request_started = threading.Event()
         release_first_request = threading.Event()
-        first_response: dict[str, Response] = {}
+        first_response: dict[str, object] = {}
         thread_errors: list[BaseException] = []
         self.app.config["RESPONSES_WEBSOCKET_UPSTREAM_MAX_RETAINED_SESSIONS"] = 1
 
@@ -1788,7 +1791,6 @@ class ResponsesWebsocketUpstreamStatefulContractTests(unittest.TestCase):
                     first_response["response"] = client.post(
                         "/v1/responses",
                         json={"model": "gpt-5.4", "input": "hello"},
-                        headers={"X-Session-Id": "session-1"},
                     )
             except BaseException as exc:  # pragma: no cover - assertion plumbing for the worker thread
                 thread_errors.append(exc)
@@ -1816,7 +1818,6 @@ class ResponsesWebsocketUpstreamStatefulContractTests(unittest.TestCase):
             second = self.client.post(
                 "/v1/responses",
                 json={"model": "gpt-5.4", "input": "second"},
-                headers={"X-Session-Id": "session-2"},
             )
 
             release_first_request.set()
@@ -2194,7 +2195,7 @@ class ResponsesWebsocketBridgeTests(unittest.TestCase):
 
     @patch("chatmock.responses_websocket_bridge.get_effective_chatgpt_auth", return_value=("token", "acct"))
     @patch("chatmock.responses_websocket_bridge.connect_upstream_websocket")
-    def test_stateful_bridge_request_send_failure_evicts_retained_socket(self, mock_connect, _mock_auth) -> None:
+    def test_stateful_bridge_request_send_failure_invalidates_retained_marker(self, mock_connect, _mock_auth) -> None:
         class FakeUpstreamWebsocket:
             def __init__(self, response_id: str) -> None:
                 self.fail_send = False
@@ -2230,28 +2231,41 @@ class ResponsesWebsocketBridgeTests(unittest.TestCase):
             )
             first_upstream.fail_send = True
             second = responses_websocket_bridge.send_responses_request_via_websocket(
-                payload={"type": "response.create", "model": "gpt-5.4", "stream": True},
+                payload={
+                    "type": "response.create",
+                    "model": "gpt-5.4",
+                    "stream": True,
+                    "previous_response_id": "resp_ws_stateful_1",
+                },
                 session_id="session-fixed",
                 stream=False,
                 stateful=True,
+                explicit_previous_response_id=True,
             )
             third = responses_websocket_bridge.send_responses_request_via_websocket(
-                payload={"type": "response.create", "model": "gpt-5.4", "stream": True},
+                payload={
+                    "type": "response.create",
+                    "model": "gpt-5.4",
+                    "stream": True,
+                    "previous_response_id": "resp_ws_stateful_1",
+                },
                 session_id="session-fixed",
                 stream=False,
                 stateful=True,
+                explicit_previous_response_id=True,
             )
 
         self.assertEqual(first.status_code, 200)
         self.assertEqual(second.status_code, 502)
         self.assertIn("request send failed", second.get_json()["error"]["message"])
-        self.assertEqual(third.status_code, 200)
-        self.assertEqual(mock_connect.call_count, 2)
+        self.assertEqual(third.status_code, 400)
+        self.assertEqual(third.get_json()["error"]["code"], "previous_response_not_found")
+        self.assertEqual(mock_connect.call_count, 1)
         self.assertEqual(first_upstream.close_calls, 1)
 
     @patch("chatmock.responses_websocket_bridge.get_effective_chatgpt_auth", return_value=("token", "acct"))
     @patch("chatmock.responses_websocket_bridge.connect_upstream_websocket")
-    def test_stateful_bridge_protocol_error_evicts_retained_socket(self, mock_connect, _mock_auth) -> None:
+    def test_stateful_bridge_protocol_error_invalidates_retained_marker(self, mock_connect, _mock_auth) -> None:
         first_upstream = FakeUpstreamWebsocket(
             [
                 json.dumps({"type": "response.created", "response": {"id": "resp_ws_stateful_1", "object": "response", "status": "in_progress"}}),
@@ -2275,22 +2289,35 @@ class ResponsesWebsocketBridgeTests(unittest.TestCase):
                 stateful=True,
             )
             second = responses_websocket_bridge.send_responses_request_via_websocket(
-                payload={"type": "response.create", "model": "gpt-5.4", "stream": True},
+                payload={
+                    "type": "response.create",
+                    "model": "gpt-5.4",
+                    "stream": True,
+                    "previous_response_id": "resp_ws_stateful_1",
+                },
                 session_id="session-fixed",
                 stream=False,
                 stateful=True,
+                explicit_previous_response_id=True,
             )
             third = responses_websocket_bridge.send_responses_request_via_websocket(
-                payload={"type": "response.create", "model": "gpt-5.4", "stream": True},
+                payload={
+                    "type": "response.create",
+                    "model": "gpt-5.4",
+                    "stream": True,
+                    "previous_response_id": "resp_ws_stateful_1",
+                },
                 session_id="session-fixed",
                 stream=False,
                 stateful=True,
+                explicit_previous_response_id=True,
             )
 
         self.assertEqual(first.status_code, 200)
         self.assertEqual(second.status_code, 502)
-        self.assertEqual(third.status_code, 200)
-        self.assertEqual(mock_connect.call_count, 2)
+        self.assertEqual(third.status_code, 400)
+        self.assertEqual(third.get_json()["error"]["code"], "previous_response_not_found")
+        self.assertEqual(mock_connect.call_count, 1)
         self.assertEqual(first_upstream.close_calls, 1)
 
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -533,6 +533,109 @@ class RouteTests(unittest.TestCase):
             ],
         )
 
+    @patch("chatmock.websocket_routes.get_effective_chatgpt_auth", return_value=("token", "acct"))
+    @patch("chatmock.websocket_routes.connect_upstream_websocket")
+    def test_responses_websocket_keeps_explicit_empty_output_authoritative_for_follow_up_contract(self, mock_connect, _mock_auth) -> None:
+        class FakeUpstreamWebsocket:
+            def __init__(self) -> None:
+                self.sent: list[str] = []
+                self._messages = [
+                    json.dumps({"type": "response.created", "response": {"id": "resp_contract_1"}}),
+                    json.dumps(
+                        {
+                            "type": "response.output_item.done",
+                            "item": {
+                                "type": "message",
+                                "role": "assistant",
+                                "id": "msg_contract_1",
+                                "content": [{"type": "output_text", "text": "assistant output"}],
+                            },
+                        }
+                    ),
+                    json.dumps(
+                        {
+                            "type": "response.completed",
+                            "response": {"id": "resp_contract_1", "output": []},
+                        }
+                    ),
+                    json.dumps({"type": "response.created", "response": {"id": "resp_contract_2"}}),
+                    json.dumps({"type": "response.completed", "response": {"id": "resp_contract_2", "output": []}}),
+                ]
+
+            def send(self, message: str) -> None:
+                self.sent.append(message)
+
+            def recv(self) -> str:
+                return self._messages.pop(0)
+
+            def close(self) -> None:
+                return None
+
+        fake_upstream = FakeUpstreamWebsocket()
+        mock_connect.return_value = fake_upstream
+
+        app = create_app()
+
+        sock = socket.socket()
+        sock.bind(("127.0.0.1", 0))
+        host, port = sock.getsockname()
+        sock.close()
+
+        server_thread = threading.Thread(
+            target=app.run,
+            kwargs={
+                "host": host,
+                "port": port,
+                "use_reloader": False,
+                "threaded": True,
+            },
+            daemon=True,
+        )
+        server_thread.start()
+        time.sleep(0.5)
+
+        with ws_connect(f"ws://{host}:{port}/v1/responses") as client:
+            client.send(json.dumps({"type": "response.create", "model": "gpt-5.4", "input": "hello"}))
+            client.recv()
+            client.recv()
+            client.recv()
+            client.send(
+                json.dumps(
+                    {
+                        "type": "response.create",
+                        "model": "gpt-5.4",
+                        "input": [
+                            {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hello"}]},
+                            {
+                                "type": "message",
+                                "role": "assistant",
+                                "id": "msg_contract_1",
+                                "content": [{"type": "output_text", "text": "assistant output"}],
+                            },
+                            {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "second"}]},
+                        ],
+                    }
+                )
+            )
+            client.recv()
+            client.recv()
+
+        follow_up = json.loads(fake_upstream.sent[1])
+        self.assertNotIn("previous_response_id", follow_up)
+        self.assertEqual(
+            follow_up["input"],
+            [
+                {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hello"}]},
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "id": "msg_contract_1",
+                    "content": [{"type": "output_text", "text": "assistant output"}],
+                },
+                {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "second"}]},
+            ],
+        )
+
     @patch("chatmock.routes_openai.start_upstream_raw_request")
     def test_responses_route_falls_back_to_full_create_when_non_input_fields_change(self, mock_start) -> None:
         mock_start.side_effect = [
@@ -2195,6 +2298,79 @@ class ResponsesWebsocketBridgeTests(unittest.TestCase):
         self.assertEqual(fake_upstream.close_calls, 1)
         self.assertIn('data: {"type":"response.completed","response":{"id":"resp_ws_1","output":[]}}', body)
         self.assertNotIn("data: [DONE]", body)
+
+    @patch("chatmock.responses_websocket_bridge.get_effective_chatgpt_auth", return_value=("token", "acct"))
+    @patch("chatmock.responses_websocket_bridge.connect_upstream_websocket")
+    def test_stateful_bridge_streaming_returns_response_before_terminal_event_contract(self, mock_connect, _mock_auth) -> None:
+        first_event_received = threading.Event()
+        allow_terminal_event = threading.Event()
+        response_ready = threading.Event()
+        response_holder: dict[str, Response] = {}
+        thread_errors: list[BaseException] = []
+
+        class BlockingUpstreamWebsocket:
+            def __init__(self) -> None:
+                self.close_calls = 0
+                self._recv_index = 0
+
+            def send(self, message: str) -> None:
+                return None
+
+            def recv(self) -> str:
+                if self._recv_index == 0:
+                    self._recv_index += 1
+                    first_event_received.set()
+                    return json.dumps({"type": "response.created", "response": {"id": "resp_stateful_stream_contract_1"}})
+                if not allow_terminal_event.wait(timeout=2):
+                    raise AssertionError("Stateful streaming contract test never released the terminal event")
+                self._recv_index += 1
+                return json.dumps(
+                    {
+                        "type": "response.completed",
+                        "response": {"id": "resp_stateful_stream_contract_1", "output": []},
+                    }
+                )
+
+            def close(self) -> None:
+                self.close_calls += 1
+                return None
+
+        def invoke_bridge() -> None:
+            try:
+                with self.app.test_request_context("/v1/responses", method="POST"):
+                    response_holder["response"] = responses_websocket_bridge.send_responses_request_via_websocket(
+                        payload={"type": "response.create", "model": "gpt-5.4", "stream": True},
+                        session_id="session-stateful-stream-contract",
+                        stream=True,
+                        stateful=True,
+                    )
+                response_ready.set()
+            except BaseException as exc:  # pragma: no cover - assertion plumbing for the worker thread
+                thread_errors.append(exc)
+                response_ready.set()
+
+        mock_connect.return_value = BlockingUpstreamWebsocket()
+
+        worker = threading.Thread(target=invoke_bridge)
+        worker.start()
+        try:
+            self.assertTrue(
+                first_event_received.wait(timeout=1),
+                "Stateful streaming contract test did not receive the first upstream event",
+            )
+            self.assertTrue(
+                response_ready.wait(timeout=0.2),
+                "Stateful streaming bridge should return a Response before the terminal upstream event arrives",
+            )
+        finally:
+            allow_terminal_event.set()
+            worker.join(timeout=2)
+
+        if thread_errors:
+            raise thread_errors[0]
+        self.assertFalse(worker.is_alive(), "Stateful streaming bridge thread did not finish")
+        self.assertTrue(response_holder["response"].content_type.startswith("text/event-stream"))
+        self.assertNotIsInstance(response_holder["response"].response, list)
 
     @patch("chatmock.responses_websocket_bridge.get_effective_chatgpt_auth", return_value=("token", "acct"))
     @patch("chatmock.responses_websocket_bridge.connect_upstream_websocket")

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -2256,8 +2256,8 @@ class ResponsesWebsocketBridgeTests(unittest.TestCase):
             )
 
         self.assertEqual(first.status_code, 200)
-        self.assertEqual(second.status_code, 502)
-        self.assertIn("request send failed", second.get_json()["error"]["message"])
+        self.assertEqual(second.status_code, 400)
+        self.assertEqual(second.get_json()["error"]["code"], "previous_response_not_found")
         self.assertEqual(third.status_code, 400)
         self.assertEqual(third.get_json()["error"]["code"], "previous_response_not_found")
         self.assertEqual(mock_connect.call_count, 1)
@@ -2314,9 +2314,58 @@ class ResponsesWebsocketBridgeTests(unittest.TestCase):
             )
 
         self.assertEqual(first.status_code, 200)
-        self.assertEqual(second.status_code, 502)
+        self.assertEqual(second.status_code, 400)
+        self.assertEqual(second.get_json()["error"]["code"], "previous_response_not_found")
         self.assertEqual(third.status_code, 400)
         self.assertEqual(third.get_json()["error"]["code"], "previous_response_not_found")
+        self.assertEqual(mock_connect.call_count, 1)
+        self.assertEqual(first_upstream.close_calls, 1)
+
+    @patch("chatmock.responses_websocket_bridge.get_effective_chatgpt_auth", return_value=("token", "acct"))
+    @patch("chatmock.responses_websocket_bridge.connect_upstream_websocket")
+    def test_stateful_bridge_closed_retained_websocket_returns_previous_response_not_found(self, mock_connect, _mock_auth) -> None:
+        first_upstream = FakeUpstreamWebsocket(
+            [
+                json.dumps(
+                    {
+                        "type": "response.created",
+                        "response": {"id": "resp_ws_stateful_closed_1", "object": "response", "status": "in_progress"},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "response.completed",
+                        "response": {"id": "resp_ws_stateful_closed_1", "object": "response", "status": "completed", "output": []},
+                    }
+                ),
+            ]
+        )
+        mock_connect.return_value = first_upstream
+
+        with self.app.test_request_context("/v1/responses", method="POST"):
+            first = responses_websocket_bridge.send_responses_request_via_websocket(
+                payload={"type": "response.create", "model": "gpt-5.4", "stream": True},
+                session_id="session-fixed",
+                stream=False,
+                stateful=True,
+            )
+            first_upstream.closed = True
+            second = responses_websocket_bridge.send_responses_request_via_websocket(
+                payload={
+                    "type": "response.create",
+                    "model": "gpt-5.4",
+                    "stream": True,
+                    "previous_response_id": "resp_ws_stateful_closed_1",
+                },
+                session_id="session-fixed",
+                stream=False,
+                stateful=True,
+                explicit_previous_response_id=True,
+            )
+
+        self.assertEqual(first.status_code, 200)
+        self.assertEqual(second.status_code, 400)
+        self.assertEqual(second.get_json()["error"]["code"], "previous_response_not_found")
         self.assertEqual(mock_connect.call_count, 1)
         self.assertEqual(first_upstream.close_calls, 1)
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1188,32 +1188,32 @@ class ResponsesWebsocketUpstreamStatefulContractTests(unittest.TestCase):
     def tearDown(self) -> None:
         reset_retained_upstream_websocket_sessions()
 
-    def test_stateful_mode_enables_route_level_previous_response_id_policy(self) -> None:
-        prepared_payload = {
-            "model": "gpt-5.4",
-            "input": [
-                {
-                    "type": "message",
-                    "role": "user",
-                    "content": [{"type": "input_text", "text": "second"}],
-                }
-            ],
-            "instructions": "base instructions",
-            "reasoning": {"effort": "medium", "summary": "auto"},
-            "include": ["reasoning.encrypted_content"],
-            "store": False,
-            "prompt_cache_key": "session-fixed",
-            "previous_response_id": "resp_stateful_1",
-        }
+    def test_stateful_mode_accepts_first_request_without_explicit_session_headers(self) -> None:
+        fake_upstream = FakeUpstreamWebsocket(
+            [
+                json.dumps(
+                    {
+                        "type": "response.created",
+                        "response": {"id": "resp_stateful_headerless_1", "object": "response", "status": "in_progress"},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "response.completed",
+                        "response": {
+                            "id": "resp_stateful_headerless_1",
+                            "object": "response",
+                            "status": "completed",
+                            "output": [],
+                        },
+                    }
+                ),
+            ]
+        )
 
         with (
-            patch(
-                "chatmock.routes_openai.prepare_responses_request_for_session",
-                return_value=SimpleNamespace(payload=prepared_payload, session_id="session-fixed"),
-            ) as mock_prepare,
-            patch(
-                "chatmock.routes_openai.responses_websocket_bridge.send_responses_request_via_websocket"
-            ) as mock_bridge,
+            patch("chatmock.responses_websocket_bridge.get_effective_chatgpt_auth", return_value=("token", "acct")),
+            patch("chatmock.responses_websocket_bridge.connect_upstream_websocket", return_value=fake_upstream) as mock_connect,
             patch(
                 "chatmock.routes_openai.start_upstream_raw_request",
                 side_effect=AssertionError(
@@ -1221,35 +1221,64 @@ class ResponsesWebsocketUpstreamStatefulContractTests(unittest.TestCase):
                 ),
             ),
         ):
-            mock_bridge.return_value = make_json_response(
-                {
-                    "id": "resp_ws_stateful_nonstream",
-                    "object": "response",
-                    "status": "completed",
-                    "output": [],
-                }
-            )
-
             response = self.client.post(
                 "/v1/responses",
-                json={
-                    "model": "gpt-5.4",
-                    "previous_response_id": "resp_client_supplied",
-                    "input": "hello",
-                },
-                headers={"X-Session-Id": "session-fixed"},
+                json={"model": "gpt-5.4", "input": "hello"},
             )
 
         self.assertEqual(response.status_code, 200)
-        mock_prepare.assert_called_once()
-        self.assertEqual(mock_prepare.call_args.args[0], "session-fixed")
-        self.assertTrue(mock_prepare.call_args.kwargs["allow_previous_response_id"])
-        self.assertEqual(
-            mock_bridge.call_args.kwargs["payload"]["previous_response_id"],
-            "resp_stateful_1",
+        self.assertEqual(mock_connect.call_count, 1)
+        outbound_payload = json.loads(fake_upstream.sent[0])
+        self.assertEqual(outbound_payload["type"], "response.create")
+        self.assertEqual(outbound_payload["model"], "gpt-5.4")
+        self.assertNotIn("previous_response_id", outbound_payload)
+
+    def test_stateful_mode_ignores_blank_explicit_session_header_on_first_request(self) -> None:
+        fake_upstream = FakeUpstreamWebsocket(
+            [
+                json.dumps(
+                    {
+                        "type": "response.created",
+                        "response": {"id": "resp_stateful_blank_header_1", "object": "response", "status": "in_progress"},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "response.completed",
+                        "response": {
+                            "id": "resp_stateful_blank_header_1",
+                            "object": "response",
+                            "status": "completed",
+                            "output": [],
+                        },
+                    }
+                ),
+            ]
         )
 
-    def test_stateful_mode_reuses_retained_websocket_for_non_stream_follow_up(self) -> None:
+        with (
+            patch("chatmock.responses_websocket_bridge.get_effective_chatgpt_auth", return_value=("token", "acct")),
+            patch("chatmock.responses_websocket_bridge.connect_upstream_websocket", return_value=fake_upstream) as mock_connect,
+            patch(
+                "chatmock.routes_openai.start_upstream_raw_request",
+                side_effect=AssertionError(
+                    "HTTP upstream transport should not be used when websocket upstream mode is enabled"
+                ),
+            ),
+        ):
+            response = self.client.post(
+                "/v1/responses",
+                json={"model": "gpt-5.4", "input": "hello"},
+                headers={"X-Session-Id": "   "},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(mock_connect.call_count, 1)
+        outbound_payload = json.loads(fake_upstream.sent[0])
+        self.assertEqual(outbound_payload["type"], "response.create")
+        self.assertNotIn("previous_response_id", outbound_payload)
+
+    def test_stateful_mode_reuses_retained_websocket_for_non_stream_follow_up_by_response_marker(self) -> None:
         fake_upstream = FakeUpstreamWebsocket(
             [
                 json.dumps(
@@ -1293,6 +1322,23 @@ class ResponsesWebsocketUpstreamStatefulContractTests(unittest.TestCase):
                         },
                     }
                 ),
+                json.dumps(
+                    {
+                        "type": "response.created",
+                        "response": {"id": "resp_stateful_3", "object": "response", "status": "in_progress"},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "response.completed",
+                        "response": {
+                            "id": "resp_stateful_3",
+                            "object": "response",
+                            "status": "completed",
+                            "output": [],
+                        },
+                    }
+                ),
             ]
         )
 
@@ -1306,41 +1352,45 @@ class ResponsesWebsocketUpstreamStatefulContractTests(unittest.TestCase):
                 ),
             ),
         ):
-            headers = {"X-Session-Id": "session-fixed"}
             first = self.client.post(
                 "/v1/responses",
                 json={"model": "gpt-5.4", "input": "hello"},
-                headers=headers,
             )
             second = self.client.post(
                 "/v1/responses",
                 json={
                     "model": "gpt-5.4",
-                    "input": [
-                        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hello"}]},
-                        {
-                            "type": "message",
-                            "role": "assistant",
-                            "id": "msg_stateful_1",
-                            "content": [{"type": "output_text", "text": "assistant output"}],
-                        },
-                        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "second"}]},
-                    ],
+                    "previous_response_id": "resp_stateful_1",
+                    "input": "second",
                 },
-                headers=headers,
+            )
+            third = self.client.post(
+                "/v1/responses",
+                json={
+                    "model": "gpt-5.4",
+                    "previous_response_id": "resp_stateful_2",
+                    "input": "third",
+                },
             )
 
         self.assertEqual(first.status_code, 200)
         self.assertEqual(second.status_code, 200)
+        self.assertEqual(third.status_code, 200)
         self.assertEqual(mock_connect.call_count, 1)
-        follow_up_payload = json.loads(fake_upstream.sent[1])
-        self.assertEqual(follow_up_payload["previous_response_id"], "resp_stateful_1")
+        second_payload = json.loads(fake_upstream.sent[1])
+        self.assertEqual(second_payload["previous_response_id"], "resp_stateful_1")
         self.assertEqual(
-            follow_up_payload["input"],
+            second_payload["input"],
             [{"type": "message", "role": "user", "content": [{"type": "input_text", "text": "second"}]}],
         )
+        third_payload = json.loads(fake_upstream.sent[2])
+        self.assertEqual(third_payload["previous_response_id"], "resp_stateful_2")
+        self.assertEqual(
+            third_payload["input"],
+            [{"type": "message", "role": "user", "content": [{"type": "input_text", "text": "third"}]}],
+        )
 
-    def test_stateful_mode_reuses_retained_websocket_for_streaming_follow_up(self) -> None:
+    def test_stateful_mode_reuses_retained_websocket_for_streaming_follow_up_by_response_marker(self) -> None:
         fake_upstream = FakeUpstreamWebsocket(
             [
                 json.dumps({"type": "response.created", "response": {"id": "resp_stream_stateful_1"}}),
@@ -1359,6 +1409,9 @@ class ResponsesWebsocketUpstreamStatefulContractTests(unittest.TestCase):
                 json.dumps({"type": "response.created", "response": {"id": "resp_stream_stateful_2"}}),
                 json.dumps({"type": "response.output_text.delta", "delta": "follow-up"}),
                 json.dumps({"type": "response.completed", "response": {"id": "resp_stream_stateful_2", "output": []}}),
+                json.dumps({"type": "response.created", "response": {"id": "resp_stream_stateful_3"}}),
+                json.dumps({"type": "response.output_text.delta", "delta": "third"}),
+                json.dumps({"type": "response.completed", "response": {"id": "resp_stream_stateful_3", "output": []}}),
             ]
         )
 
@@ -1372,44 +1425,41 @@ class ResponsesWebsocketUpstreamStatefulContractTests(unittest.TestCase):
                 ),
             ),
         ):
-            headers = {"X-Session-Id": "session-fixed"}
             first = self.client.post(
                 "/v1/responses",
                 json={"model": "gpt-5.4", "input": "hello", "stream": True},
-                headers=headers,
             )
             second = self.client.post(
                 "/v1/responses",
                 json={
                     "model": "gpt-5.4",
                     "stream": True,
-                    "input": [
-                        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hello"}]},
-                        {
-                            "type": "message",
-                            "role": "assistant",
-                            "id": "msg_stream_stateful_1",
-                            "content": [{"type": "output_text", "text": "assistant output"}],
-                        },
-                        {
-                            "type": "message",
-                            "role": "user",
-                            "content": [{"type": "input_text", "text": "stream follow-up"}],
-                        },
-                    ],
+                    "previous_response_id": "resp_stream_stateful_1",
+                    "input": "stream follow-up",
                 },
-                headers=headers,
+            )
+            third = self.client.post(
+                "/v1/responses",
+                json={
+                    "model": "gpt-5.4",
+                    "stream": True,
+                    "previous_response_id": "resp_stream_stateful_2",
+                    "input": "stream third",
+                },
             )
 
         self.assertEqual(first.status_code, 200)
         self.assertEqual(second.status_code, 200)
+        self.assertEqual(third.status_code, 200)
         self.assertEqual(mock_connect.call_count, 1)
         self.assertTrue(second.content_type.startswith("text/event-stream"))
+        self.assertTrue(third.content_type.startswith("text/event-stream"))
         self.assertIn("response.output_text.delta", second.get_data(as_text=True))
-        follow_up_payload = json.loads(fake_upstream.sent[1])
-        self.assertEqual(follow_up_payload["previous_response_id"], "resp_stream_stateful_1")
+        self.assertIn("response.output_text.delta", third.get_data(as_text=True))
+        second_payload = json.loads(fake_upstream.sent[1])
+        self.assertEqual(second_payload["previous_response_id"], "resp_stream_stateful_1")
         self.assertEqual(
-            follow_up_payload["input"],
+            second_payload["input"],
             [
                 {
                     "type": "message",
@@ -1418,31 +1468,70 @@ class ResponsesWebsocketUpstreamStatefulContractTests(unittest.TestCase):
                 }
             ],
         )
+        third_payload = json.loads(fake_upstream.sent[2])
+        self.assertEqual(third_payload["previous_response_id"], "resp_stream_stateful_2")
+        self.assertEqual(
+            third_payload["input"],
+            [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "stream third"}],
+                }
+            ],
+        )
 
-    def test_stateful_mode_keeps_explicit_previous_response_id_and_resets_retained_session(self) -> None:
+    def test_stateful_mode_returns_retryable_previous_response_not_found_for_non_stream_stale_marker(self) -> None:
+        with (
+            patch(
+                "chatmock.routes_openai.start_upstream_raw_request",
+                side_effect=AssertionError(
+                    "HTTP upstream transport should not be used when websocket upstream mode is enabled"
+                ),
+            ),
+            patch(
+                "chatmock.responses_websocket_bridge.get_effective_chatgpt_auth",
+                side_effect=AssertionError(
+                    "Stateful stale-marker requests should be rejected before bridge auth lookup"
+                ),
+            ),
+            patch(
+                "chatmock.responses_websocket_bridge.connect_upstream_websocket",
+                side_effect=AssertionError(
+                    "Stateful stale-marker requests should be rejected before websocket connect"
+                ),
+            ),
+        ):
+            response = self.client.post(
+                "/v1/responses",
+                json={
+                    "model": "gpt-5.4",
+                    "previous_response_id": "resp_missing_stateful_marker",
+                    "input": "hello",
+                },
+            )
+
+        body = response.get_json()
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(body.get("error", {}).get("code"), "previous_response_not_found")
+
+    def test_stateful_mode_returns_retryable_previous_response_not_found_for_lost_retained_socket(self) -> None:
         first_upstream = FakeUpstreamWebsocket(
             [
                 json.dumps(
                     {
                         "type": "response.created",
-                        "response": {"id": "resp_stateful_reset_1", "object": "response", "status": "in_progress"},
+                        "response": {"id": "resp_stateful_lost_1", "object": "response", "status": "in_progress"},
                     }
                 ),
                 json.dumps(
                     {
                         "type": "response.completed",
                         "response": {
-                            "id": "resp_stateful_reset_1",
+                            "id": "resp_stateful_lost_1",
                             "object": "response",
                             "status": "completed",
-                            "output": [
-                                {
-                                    "type": "message",
-                                    "role": "assistant",
-                                    "id": "msg_stateful_reset_1",
-                                    "content": [{"type": "output_text", "text": "assistant output"}],
-                                }
-                            ],
+                            "output": [],
                         },
                     }
                 ),
@@ -1452,18 +1541,11 @@ class ResponsesWebsocketUpstreamStatefulContractTests(unittest.TestCase):
             [
                 json.dumps(
                     {
-                        "type": "response.created",
-                        "response": {"id": "resp_stateful_reset_2", "object": "response", "status": "in_progress"},
-                    }
-                ),
-                json.dumps(
-                    {
-                        "type": "response.completed",
-                        "response": {
-                            "id": "resp_stateful_reset_2",
-                            "object": "response",
-                            "status": "completed",
-                            "output": [],
+                        "type": "error",
+                        "status_code": 400,
+                        "error": {
+                            "message": "No response found for previous_response_id resp_stateful_lost_1.",
+                            "code": "previous_response_not_found",
                         },
                     }
                 ),
@@ -1475,7 +1557,7 @@ class ResponsesWebsocketUpstreamStatefulContractTests(unittest.TestCase):
             patch(
                 "chatmock.responses_websocket_bridge.connect_upstream_websocket",
                 side_effect=[first_upstream, second_upstream],
-            ) as mock_connect,
+            ),
             patch(
                 "chatmock.routes_openai.start_upstream_raw_request",
                 side_effect=AssertionError(
@@ -1483,115 +1565,29 @@ class ResponsesWebsocketUpstreamStatefulContractTests(unittest.TestCase):
                 ),
             ),
         ):
-            headers = {"X-Session-Id": "session-fixed"}
             first = self.client.post(
                 "/v1/responses",
                 json={"model": "gpt-5.4", "input": "hello"},
-                headers=headers,
             )
+            reset_retained_upstream_websocket_sessions()
             second = self.client.post(
                 "/v1/responses",
                 json={
                     "model": "gpt-5.4",
-                    "previous_response_id": "resp_client_reset",
-                    "input": [
-                        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hello"}]},
-                        {
-                            "type": "message",
-                            "role": "assistant",
-                            "id": "msg_stateful_reset_1",
-                            "content": [{"type": "output_text", "text": "assistant output"}],
-                        },
-                        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "second"}]},
-                    ],
+                    "previous_response_id": "resp_stateful_lost_1",
+                    "input": "second",
                 },
-                headers=headers,
             )
 
+        body = second.get_json()
         self.assertEqual(first.status_code, 200)
-        self.assertEqual(second.status_code, 200)
-        self.assertEqual(mock_connect.call_count, 2)
-        follow_up_payload = json.loads(second_upstream.sent[0])
-        self.assertEqual(follow_up_payload["previous_response_id"], "resp_client_reset")
-        self.assertEqual(
-            follow_up_payload["input"],
-            [
-                {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hello"}]},
-                {
-                    "type": "message",
-                    "role": "assistant",
-                    "id": "msg_stateful_reset_1",
-                    "content": [{"type": "output_text", "text": "assistant output"}],
-                },
-                {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "second"}]},
-            ],
-        )
+        self.assertEqual(second.status_code, 400)
+        self.assertEqual(body["error"]["code"], "previous_response_not_found")
 
-    def test_stateful_mode_rejects_invalid_explicit_session_id_before_any_transport_layer(self) -> None:
-        with (
-            patch(
-                "chatmock.routes_openai.start_upstream_raw_request",
-                side_effect=AssertionError(
-                    "HTTP upstream transport should not be used when websocket upstream mode is enabled"
-                ),
-            ),
-            patch(
-                "chatmock.responses_websocket_bridge.get_effective_chatgpt_auth",
-                side_effect=AssertionError(
-                    "Stateful invalid session-id requests must be rejected before bridge auth lookup"
-                ),
-            ),
-            patch(
-                "chatmock.responses_websocket_bridge.connect_upstream_websocket",
-                side_effect=AssertionError(
-                    "Stateful invalid session-id requests must be rejected before websocket connect"
-                ),
-            ),
-        ):
-            response = self.client.post(
-                "/v1/responses",
-                json={"model": "gpt-5.4", "input": "hello"},
-                headers={"X-Session-Id": "   "},
-            )
-
-        body = response.get_json()
-        self.assertEqual(response.status_code, 400)
-        self.assertIn("X-Session-Id", body["error"]["message"])
-
-    def test_stateful_mode_rejects_missing_explicit_session_id_before_any_transport_layer(self) -> None:
-        with (
-            patch(
-                "chatmock.routes_openai.start_upstream_raw_request",
-                side_effect=AssertionError(
-                    "HTTP upstream transport should not be used when websocket upstream mode is enabled"
-                ),
-            ),
-            patch(
-                "chatmock.responses_websocket_bridge.get_effective_chatgpt_auth",
-                side_effect=AssertionError(
-                    "Stateful missing session-id requests must be rejected before bridge auth lookup"
-                ),
-            ),
-            patch(
-                "chatmock.responses_websocket_bridge.connect_upstream_websocket",
-                side_effect=AssertionError(
-                    "Stateful missing session-id requests must be rejected before websocket connect"
-                ),
-            ),
-        ):
-            response = self.client.post(
-                "/v1/responses",
-                json={"model": "gpt-5.4", "input": "hello"},
-            )
-
-        body = response.get_json()
-        self.assertEqual(response.status_code, 400)
-        self.assertIn("X-Session-Id", body["error"]["message"])
-
-    def test_stateful_mode_rejects_same_session_contention_with_conflict(self) -> None:
-        first_request_started = threading.Event()
-        release_first_request = threading.Event()
-        first_response: dict[str, Response] = {}
+    def test_stateful_mode_rejects_duplicate_follow_up_requests_for_same_marker_with_conflict(self) -> None:
+        first_follow_up_started = threading.Event()
+        release_first_follow_up = threading.Event()
+        first_follow_up_response: dict[str, Response] = {}
         thread_errors: list[BaseException] = []
 
         class BlockingUpstreamWebsocket(FakeUpstreamWebsocket):
@@ -1605,38 +1601,35 @@ class ResponsesWebsocketUpstreamStatefulContractTests(unittest.TestCase):
                                 "response": {"id": "resp_stateful_inflight_1", "output": []},
                             }
                         ),
+                        json.dumps({"type": "response.created", "response": {"id": "resp_stateful_inflight_2"}}),
+                        json.dumps(
+                            {
+                                "type": "response.completed",
+                                "response": {"id": "resp_stateful_inflight_2", "output": []},
+                            }
+                        ),
                     ]
                 )
-                self._blocked = False
+                self._recv_calls = 0
 
             def recv(self) -> str:
-                if not self._blocked:
-                    self._blocked = True
-                    first_request_started.set()
-                    if not release_first_request.wait(timeout=2):
-                        raise AssertionError("First stateful request did not reach the blocking point")
+                if self._recv_calls == 2:
+                    first_follow_up_started.set()
+                    if not release_first_follow_up.wait(timeout=2):
+                        raise AssertionError("First follow-up request did not reach the blocking point")
+                self._recv_calls += 1
                 return super().recv()
 
-        first_upstream = BlockingUpstreamWebsocket()
-        second_upstream = FakeUpstreamWebsocket(
-            [
-                json.dumps({"type": "response.created", "response": {"id": "resp_stateful_inflight_2"}}),
-                json.dumps(
-                    {
-                        "type": "response.completed",
-                        "response": {"id": "resp_stateful_inflight_2", "output": []},
-                    }
-                ),
-            ]
-        )
-
-        def send_first_request() -> None:
+        def send_first_follow_up_request() -> None:
             try:
                 with self.app.test_client() as client:
-                    first_response["response"] = client.post(
+                    first_follow_up_response["response"] = client.post(
                         "/v1/responses",
-                        json={"model": "gpt-5.4", "input": "hello"},
-                        headers={"X-Session-Id": "session-fixed"},
+                        json={
+                            "model": "gpt-5.4",
+                            "previous_response_id": "resp_stateful_inflight_1",
+                            "input": "second",
+                        },
                     )
             except BaseException as exc:  # pragma: no cover - assertion plumbing for the worker thread
                 thread_errors.append(exc)
@@ -1645,7 +1638,7 @@ class ResponsesWebsocketUpstreamStatefulContractTests(unittest.TestCase):
             patch("chatmock.responses_websocket_bridge.get_effective_chatgpt_auth", return_value=("token", "acct")),
             patch(
                 "chatmock.responses_websocket_bridge.connect_upstream_websocket",
-                side_effect=[first_upstream, second_upstream],
+                return_value=BlockingUpstreamWebsocket(),
             ),
             patch(
                 "chatmock.routes_openai.start_upstream_raw_request",
@@ -1654,28 +1647,98 @@ class ResponsesWebsocketUpstreamStatefulContractTests(unittest.TestCase):
                 ),
             ),
         ):
-            first_thread = threading.Thread(target=send_first_request)
+            initial = self.client.post(
+                "/v1/responses",
+                json={"model": "gpt-5.4", "input": "hello"},
+            )
+
+            first_thread = threading.Thread(target=send_first_follow_up_request)
             first_thread.start()
             self.assertTrue(
-                first_request_started.wait(timeout=1),
-                "First stateful request did not block before issuing the contention request",
+                first_follow_up_started.wait(timeout=1),
+                "First follow-up request did not block before issuing the contention request",
             )
 
             second = self.client.post(
                 "/v1/responses",
-                json={"model": "gpt-5.4", "input": "second"},
-                headers={"X-Session-Id": "session-fixed"},
+                json={
+                    "model": "gpt-5.4",
+                    "previous_response_id": "resp_stateful_inflight_1",
+                    "input": "duplicate",
+                },
             )
 
-            release_first_request.set()
+            release_first_follow_up.set()
             first_thread.join(timeout=2)
 
         if thread_errors:
             raise thread_errors[0]
-        self.assertFalse(first_thread.is_alive(), "First stateful request thread did not finish")
-        self.assertEqual(first_response["response"].status_code, 200)
+        self.assertFalse(first_thread.is_alive(), "First follow-up request thread did not finish")
+        self.assertEqual(initial.status_code, 200)
+        self.assertEqual(first_follow_up_response["response"].status_code, 200)
         self.assertEqual(second.status_code, 409)
         self.assertIn("already in progress", second.get_json()["error"]["message"])
+
+    def test_stateful_streaming_invalid_marker_currently_surfaces_as_sse_error_characterization(self) -> None:
+        fake_upstream = FakeUpstreamWebsocket(
+            [
+                json.dumps(
+                    {
+                        "type": "response.created",
+                        "response": {"id": "resp_stream_characterization_1", "object": "response", "status": "in_progress"},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "response.completed",
+                        "response": {
+                            "id": "resp_stream_characterization_1",
+                            "object": "response",
+                            "status": "completed",
+                            "output": [],
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "error",
+                        "status_code": 400,
+                        "error": {
+                            "message": "No response found for previous_response_id resp_stream_characterization_1.",
+                            "code": "previous_response_not_found",
+                        },
+                    }
+                ),
+            ]
+        )
+
+        with (
+            patch("chatmock.responses_websocket_bridge.get_effective_chatgpt_auth", return_value=("token", "acct")),
+            patch("chatmock.responses_websocket_bridge.connect_upstream_websocket", return_value=fake_upstream),
+            patch(
+                "chatmock.routes_openai.start_upstream_raw_request",
+                side_effect=AssertionError(
+                    "HTTP upstream transport should not be used when websocket upstream mode is enabled"
+                ),
+            ),
+        ):
+            first = self.client.post(
+                "/v1/responses",
+                json={"model": "gpt-5.4", "input": "hello"},
+                headers={"X-Session-Id": "session-fixed"},
+            )
+            second = self.client.post(
+                "/v1/responses",
+                json={"model": "gpt-5.4", "input": "second", "stream": True},
+                headers={"X-Session-Id": "session-fixed"},
+            )
+
+        self.assertEqual(first.status_code, 200)
+        self.assertEqual(second.status_code, 200)
+        self.assertTrue(second.content_type.startswith("text/event-stream"))
+        payload = second.get_data(as_text=True)
+        self.assertIn('"code":"previous_response_not_found"', payload)
+        self.assertIn('"status_code":400', payload)
 
     def test_stateful_mode_applies_route_level_retained_session_capacity_limit(self) -> None:
         first_request_started = threading.Event()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -54,6 +54,13 @@ class RouteTests(unittest.TestCase):
         self.app = create_app()
         self.client = self.app.test_client()
 
+    def test_create_app_defaults_responses_websocket_upstream_disabled(self) -> None:
+        self.assertFalse(self.app.config["RESPONSES_WEBSOCKET_UPSTREAM"])
+
+    def test_create_app_can_enable_responses_websocket_upstream(self) -> None:
+        app = create_app(responses_websocket_upstream=True)
+        self.assertTrue(app.config["RESPONSES_WEBSOCKET_UPSTREAM"])
+
     def test_openai_models_list(self) -> None:
         response = self.client.get("/v1/models")
         body = response.get_json()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -12,7 +12,10 @@ from unittest.mock import patch
 from chatmock import responses_websocket_bridge
 from chatmock.app import create_app
 from chatmock.responses_api import normalize_responses_payload
-from chatmock.responses_websocket_sessions import reset_retained_upstream_websocket_sessions
+from chatmock.responses_websocket_sessions import (
+    RetainedUpstreamWebsocketLease,
+    reset_retained_upstream_websocket_sessions,
+)
 from chatmock.session import reset_session_state
 from flask import Response
 from websockets.sync.client import connect as ws_connect
@@ -1633,6 +1636,7 @@ class ResponsesWebsocketUpstreamStatefulContractTests(unittest.TestCase):
                 "/v1/responses",
                 json={"model": "gpt-5.4", "input": "hello", "stream": True},
             )
+            first_body = first.get_data(as_text=True)
             second = self.client.post(
                 "/v1/responses",
                 json={
@@ -1642,6 +1646,7 @@ class ResponsesWebsocketUpstreamStatefulContractTests(unittest.TestCase):
                     "input": "stream follow-up",
                 },
             )
+            second_body = second.get_data(as_text=True)
             third = self.client.post(
                 "/v1/responses",
                 json={
@@ -1651,6 +1656,7 @@ class ResponsesWebsocketUpstreamStatefulContractTests(unittest.TestCase):
                     "input": "stream third",
                 },
             )
+            third_body = third.get_data(as_text=True)
 
         self.assertEqual(first.status_code, 200)
         self.assertEqual(second.status_code, 200)
@@ -1658,8 +1664,9 @@ class ResponsesWebsocketUpstreamStatefulContractTests(unittest.TestCase):
         self.assertEqual(mock_connect.call_count, 1)
         self.assertTrue(second.content_type.startswith("text/event-stream"))
         self.assertTrue(third.content_type.startswith("text/event-stream"))
-        self.assertIn("response.output_text.delta", second.get_data(as_text=True))
-        self.assertIn("response.output_text.delta", third.get_data(as_text=True))
+        self.assertIn("response.output_item.done", first_body)
+        self.assertIn("response.output_text.delta", second_body)
+        self.assertIn("response.output_text.delta", third_body)
         second_payload = json.loads(fake_upstream.sent[1])
         self.assertEqual(second_payload["previous_response_id"], "resp_stream_stateful_1")
         self.assertEqual(
@@ -2302,7 +2309,7 @@ class ResponsesWebsocketBridgeTests(unittest.TestCase):
     @patch("chatmock.responses_websocket_bridge.get_effective_chatgpt_auth", return_value=("token", "acct"))
     @patch("chatmock.responses_websocket_bridge.connect_upstream_websocket")
     def test_stateful_bridge_streaming_returns_response_before_terminal_event_contract(self, mock_connect, _mock_auth) -> None:
-        first_event_received = threading.Event()
+        recv_started = threading.Event()
         allow_terminal_event = threading.Event()
         response_ready = threading.Event()
         response_holder: dict[str, Response] = {}
@@ -2317,13 +2324,12 @@ class ResponsesWebsocketBridgeTests(unittest.TestCase):
                 return None
 
             def recv(self) -> str:
-                if self._recv_index == 0:
-                    self._recv_index += 1
-                    first_event_received.set()
-                    return json.dumps({"type": "response.created", "response": {"id": "resp_stateful_stream_contract_1"}})
+                recv_started.set()
                 if not allow_terminal_event.wait(timeout=2):
                     raise AssertionError("Stateful streaming contract test never released the terminal event")
                 self._recv_index += 1
+                if self._recv_index == 1:
+                    return json.dumps({"type": "response.created", "response": {"id": "resp_stateful_stream_contract_1"}})
                 return json.dumps(
                     {
                         "type": "response.completed",
@@ -2355,14 +2361,17 @@ class ResponsesWebsocketBridgeTests(unittest.TestCase):
         worker.start()
         try:
             self.assertTrue(
-                first_event_received.wait(timeout=1),
-                "Stateful streaming contract test did not receive the first upstream event",
-            )
-            self.assertTrue(
                 response_ready.wait(timeout=0.2),
                 "Stateful streaming bridge should return a Response before the terminal upstream event arrives",
             )
+            self.assertFalse(
+                recv_started.is_set(),
+                "Stateful streaming bridge should not consume the upstream iterator before the HTTP response is returned",
+            )
         finally:
+            response = response_holder.get("response")
+            if response is not None:
+                response.close()
             allow_terminal_event.set()
             worker.join(timeout=2)
 
@@ -2371,6 +2380,128 @@ class ResponsesWebsocketBridgeTests(unittest.TestCase):
         self.assertFalse(worker.is_alive(), "Stateful streaming bridge thread did not finish")
         self.assertTrue(response_holder["response"].content_type.startswith("text/event-stream"))
         self.assertNotIsInstance(response_holder["response"].response, list)
+
+    @patch("chatmock.responses_websocket_bridge.get_effective_chatgpt_auth", return_value=("token", "acct"))
+    @patch("chatmock.responses_websocket_bridge.connect_upstream_websocket")
+    @patch("chatmock.responses_websocket_bridge._sse_response")
+    def test_stateful_streaming_passes_a_generator_to__sse_response(
+        self,
+        mock_sse_response,
+        mock_connect,
+        _mock_auth,
+    ) -> None:
+        fake_upstream = FakeUpstreamWebsocket(
+            [
+                json.dumps({"type": "response.created", "response": {"id": "resp_stateful_stream_1"}}),
+                json.dumps({"type": "response.completed", "response": {"id": "resp_stateful_stream_1", "output": []}}),
+            ]
+        )
+        mock_connect.return_value = fake_upstream
+
+        def make_response(payload_iter) -> Response:
+            return Response(payload_iter, status=200, mimetype="text/event-stream")
+
+        mock_sse_response.side_effect = make_response
+
+        with self.app.test_request_context("/v1/responses", method="POST"):
+            response = responses_websocket_bridge.send_responses_request_via_websocket(
+                payload={"type": "response.create", "model": "gpt-5.4", "stream": True},
+                session_id="session-stateful-stream-generator",
+                stream=True,
+                stateful=True,
+            )
+
+        try:
+            payload_iter = mock_sse_response.call_args.args[0]
+            self.assertTrue(inspect.isgenerator(payload_iter))
+            self.assertNotIsInstance(payload_iter, list)
+            self.assertTrue(response.content_type.startswith("text/event-stream"))
+        finally:
+            response.close()
+
+    @patch("chatmock.responses_websocket_bridge.release_retained_upstream_websocket")
+    def test_stateful_streaming_terminal_success_retains_lease_once(self, mock_release_retained) -> None:
+        fake_upstream = FakeUpstreamWebsocket(
+            [
+                json.dumps({"type": "response.created", "response": {"id": "resp_stateful_stream_success_1"}}),
+                json.dumps({"type": "response.completed", "response": {"id": "resp_stateful_stream_success_1", "output": []}}),
+            ]
+        )
+        lease = RetainedUpstreamWebsocketLease(response_id=None, upstream_ws=fake_upstream, created=True)
+
+        list(
+            responses_websocket_bridge._iter_streaming_events(
+                fake_upstream,
+                session_id="session-stateful-stream-success",
+                verbose=False,
+                retained_lease=lease,
+            )
+        )
+
+        mock_release_retained.assert_called_once_with(
+            lease,
+            retain=True,
+            response_id="resp_stateful_stream_success_1",
+        )
+
+    @patch("chatmock.responses_websocket_bridge.release_retained_upstream_websocket")
+    def test_stateful_streaming_terminal_error_releases_lease_once(self, mock_release_retained) -> None:
+        fake_upstream = FakeUpstreamWebsocket(
+            [
+                json.dumps({"type": "response.created", "response": {"id": "resp_stateful_stream_error_1"}}),
+                json.dumps(
+                    {
+                        "type": "response.failed",
+                        "response": {
+                            "id": "resp_stateful_stream_error_1",
+                            "error": {"message": "upstream failed"},
+                        },
+                    }
+                ),
+            ]
+        )
+        lease = RetainedUpstreamWebsocketLease(response_id=None, upstream_ws=fake_upstream, created=True)
+
+        list(
+            responses_websocket_bridge._iter_streaming_events(
+                fake_upstream,
+                session_id="session-stateful-stream-error",
+                verbose=False,
+                retained_lease=lease,
+            )
+        )
+
+        mock_release_retained.assert_called_once_with(
+            lease,
+            retain=False,
+            response_id="resp_stateful_stream_error_1",
+        )
+
+    @patch("chatmock.responses_websocket_bridge.release_retained_upstream_websocket")
+    def test_stateful_streaming_abort_releases_retained_lease_once(self, mock_release_retained) -> None:
+        fake_upstream = FakeUpstreamWebsocket(
+            [
+                json.dumps({"type": "response.created", "response": {"id": "resp_stateful_stream_abort_1"}}),
+                json.dumps({"type": "response.output_text.delta", "delta": "partial"}),
+            ]
+        )
+        lease = RetainedUpstreamWebsocketLease(response_id=None, upstream_ws=fake_upstream, created=True)
+
+        stream_iter = responses_websocket_bridge._iter_streaming_events(
+            fake_upstream,
+            session_id="session-stateful-stream-abort",
+            verbose=False,
+            retained_lease=lease,
+        )
+
+        next(stream_iter)
+        stream_iter.close()
+
+        mock_release_retained.assert_called_once_with(
+            lease,
+            retain=False,
+            response_id="resp_stateful_stream_abort_1",
+        )
 
     @patch("chatmock.responses_websocket_bridge.get_effective_chatgpt_auth", return_value=("token", "acct"))
     @patch("chatmock.responses_websocket_bridge.connect_upstream_websocket")

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -8,7 +8,8 @@ import unittest
 from unittest.mock import patch
 
 from chatmock.app import create_app
-from chatmock.session import reset_session_state
+from chatmock.session import note_responses_final_response, reset_session_state
+from flask import Response
 from websockets.sync.client import connect as ws_connect
 
 
@@ -46,6 +47,14 @@ class FakeUpstream:
 
     def close(self) -> None:
         return None
+
+
+def make_json_response(body: dict[str, object], *, status_code: int = 200) -> Response:
+    return Response(json.dumps(body), status=status_code, mimetype="application/json")
+
+
+def make_sse_response(payload: bytes, *, status_code: int = 200) -> Response:
+    return Response(payload, status=status_code, mimetype="text/event-stream")
 
 
 class RouteTests(unittest.TestCase):
@@ -659,6 +668,304 @@ class RouteTests(unittest.TestCase):
             follow_up["input"],
             [{"type": "message", "role": "user", "content": [{"type": "input_text", "text": "second"}]}],
         )
+
+
+class ResponsesWebsocketUpstreamContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        reset_session_state()
+        self.app = create_app()
+        self.client = self.app.test_client()
+
+    def test_disabled_mode_keeps_http_upstream_transport(self) -> None:
+        with (
+            patch("chatmock.routes_openai.responses_websocket_bridge.send_responses_request_via_websocket") as mock_bridge,
+            patch("chatmock.routes_openai.start_upstream_raw_request") as mock_start,
+        ):
+            mock_start.return_value = (
+                FakeUpstream(
+                    [
+                        {
+                            "type": "response.created",
+                            "response": {"id": "resp_http_1", "object": "response", "status": "in_progress"},
+                        },
+                        {
+                            "type": "response.completed",
+                            "response": {
+                                "id": "resp_http_1",
+                                "object": "response",
+                                "status": "completed",
+                                "output": [],
+                            },
+                        },
+                    ],
+                    headers={"Content-Type": "text/event-stream"},
+                ),
+                None,
+            )
+
+            response = self.client.post(
+                "/v1/responses",
+                json={"model": "gpt-5.4", "input": "hello"},
+            )
+
+        body = response.get_json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(body["id"], "resp_http_1")
+        mock_start.assert_called_once()
+        mock_bridge.assert_not_called()
+
+    def test_enabled_mode_uses_websocket_bridge_for_non_stream_requests(self) -> None:
+        app = create_app(responses_websocket_upstream=True)
+        client = app.test_client()
+
+        with (
+            patch(
+                "chatmock.routes_openai.responses_websocket_bridge.send_responses_request_via_websocket"
+            ) as mock_bridge,
+            patch(
+                "chatmock.routes_openai.start_upstream_raw_request",
+                side_effect=AssertionError(
+                    "HTTP upstream transport should not be used when websocket upstream mode is enabled"
+                ),
+            ),
+        ):
+            mock_bridge.return_value = make_json_response(
+                {
+                    "id": "resp_ws_nonstream",
+                    "object": "response",
+                    "status": "completed",
+                    "output": [],
+                }
+            )
+
+            response = client.post(
+                "/v1/responses",
+                json={"model": "gpt-5.4", "input": "hello"},
+            )
+
+        body = response.get_json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(body["id"], "resp_ws_nonstream")
+        mock_bridge.assert_called_once()
+        self.assertFalse(mock_bridge.call_args.kwargs["stream"])
+        self.assertTrue(mock_bridge.call_args.kwargs["payload"]["stream"])
+        self.assertNotIn("previous_response_id", mock_bridge.call_args.kwargs["payload"])
+
+    def test_enabled_mode_uses_websocket_bridge_for_streaming_requests(self) -> None:
+        app = create_app(responses_websocket_upstream=True)
+        client = app.test_client()
+
+        with (
+            patch(
+                "chatmock.routes_openai.responses_websocket_bridge.send_responses_request_via_websocket"
+            ) as mock_bridge,
+            patch(
+                "chatmock.routes_openai.start_upstream_raw_request",
+                side_effect=AssertionError(
+                    "HTTP upstream transport should not be used when websocket upstream mode is enabled"
+                ),
+            ),
+        ):
+            mock_bridge.return_value = make_sse_response(
+                b'data: {"type":"response.output_text.delta","delta":"hello"}\n\n'
+            )
+
+            response = client.post(
+                "/v1/responses",
+                json={"model": "gpt-5.4", "input": "hello", "stream": True},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.content_type.startswith("text/event-stream"))
+        self.assertIn("response.output_text.delta", response.get_data(as_text=True))
+        mock_bridge.assert_called_once()
+        self.assertTrue(mock_bridge.call_args.kwargs["stream"])
+        self.assertTrue(mock_bridge.call_args.kwargs["payload"]["stream"])
+
+    def test_enabled_mode_keeps_http_previous_response_id_disabled(self) -> None:
+        app = create_app(responses_websocket_upstream=True)
+        client = app.test_client()
+        bridge_calls: list[dict[str, object]] = []
+        bridge_bodies = [
+            {
+                "id": "resp_ws_1",
+                "object": "response",
+                "status": "completed",
+                "output": [
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "id": "msg_1",
+                        "content": [{"type": "output_text", "text": "assistant output"}],
+                    }
+                ],
+            },
+            {
+                "id": "resp_ws_2",
+                "object": "response",
+                "status": "completed",
+                "output": [],
+            },
+        ]
+
+        def bridge_side_effect(*, payload, session_id, stream, verbose=False):
+            body = bridge_bodies[len(bridge_calls)]
+            note_responses_final_response(session_id, body)
+            bridge_calls.append(
+                {
+                    "payload": payload,
+                    "session_id": session_id,
+                    "stream": stream,
+                    "verbose": verbose,
+                }
+            )
+            return make_json_response(body)
+
+        with (
+            patch(
+                "chatmock.routes_openai.responses_websocket_bridge.send_responses_request_via_websocket",
+                side_effect=bridge_side_effect,
+            ),
+            patch(
+                "chatmock.routes_openai.start_upstream_raw_request",
+                side_effect=AssertionError(
+                    "HTTP upstream transport should not be used when websocket upstream mode is enabled"
+                ),
+            ),
+        ):
+            headers = {"X-Session-Id": "session-fixed"}
+            first = client.post(
+                "/v1/responses",
+                json={"model": "gpt-5.4", "input": "hello"},
+                headers=headers,
+            )
+            second = client.post(
+                "/v1/responses",
+                json={
+                    "model": "gpt-5.4",
+                    "input": [
+                        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hello"}]},
+                        {
+                            "type": "message",
+                            "role": "assistant",
+                            "id": "msg_1",
+                            "content": [{"type": "output_text", "text": "assistant output"}],
+                        },
+                        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "second"}]},
+                    ],
+                },
+                headers=headers,
+            )
+
+        self.assertEqual(first.status_code, 200)
+        self.assertEqual(second.status_code, 200)
+        self.assertEqual(len(bridge_calls), 2)
+        second_payload = bridge_calls[1]["payload"]
+        self.assertFalse(bridge_calls[1]["stream"])
+        self.assertNotIn("previous_response_id", second_payload)
+        self.assertEqual(
+            second_payload["input"],
+            [
+                {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hello"}]},
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "id": "msg_1",
+                    "content": [{"type": "output_text", "text": "assistant output"}],
+                },
+                {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "second"}]},
+            ],
+        )
+
+    def test_enabled_mode_surfaces_websocket_connect_failure_as_http_error(self) -> None:
+        app = create_app(responses_websocket_upstream=True)
+        client = app.test_client()
+
+        with (
+            patch(
+                "chatmock.routes_openai.responses_websocket_bridge.send_responses_request_via_websocket"
+            ) as mock_bridge,
+            patch(
+                "chatmock.routes_openai.start_upstream_raw_request",
+                side_effect=AssertionError(
+                    "HTTP upstream transport should not be used when websocket upstream mode is enabled"
+                ),
+            ),
+        ):
+            mock_bridge.return_value = make_json_response(
+                {"error": {"message": "Upstream websocket connection failed: dial tcp refused"}},
+                status_code=502,
+            )
+
+            response = client.post(
+                "/v1/responses",
+                json={"model": "gpt-5.4", "input": "hello"},
+            )
+
+        body = response.get_json()
+        self.assertEqual(response.status_code, 502)
+        self.assertEqual(body["error"]["message"], "Upstream websocket connection failed: dial tcp refused")
+        mock_bridge.assert_called_once()
+
+    def test_enabled_mode_surfaces_midstream_connection_loss_as_http_error(self) -> None:
+        app = create_app(responses_websocket_upstream=True)
+        client = app.test_client()
+
+        with (
+            patch(
+                "chatmock.routes_openai.responses_websocket_bridge.send_responses_request_via_websocket"
+            ) as mock_bridge,
+            patch(
+                "chatmock.routes_openai.start_upstream_raw_request",
+                side_effect=AssertionError(
+                    "HTTP upstream transport should not be used when websocket upstream mode is enabled"
+                ),
+            ),
+        ):
+            mock_bridge.return_value = make_json_response(
+                {"error": {"message": "Upstream websocket closed before response.completed"}},
+                status_code=502,
+            )
+
+            response = client.post(
+                "/v1/responses",
+                json={"model": "gpt-5.4", "input": "hello"},
+            )
+
+        body = response.get_json()
+        self.assertEqual(response.status_code, 502)
+        self.assertEqual(body["error"]["message"], "Upstream websocket closed before response.completed")
+        mock_bridge.assert_called_once()
+
+    def test_enabled_mode_surfaces_malformed_upstream_events_as_http_error(self) -> None:
+        app = create_app(responses_websocket_upstream=True)
+        client = app.test_client()
+
+        with (
+            patch(
+                "chatmock.routes_openai.responses_websocket_bridge.send_responses_request_via_websocket"
+            ) as mock_bridge,
+            patch(
+                "chatmock.routes_openai.start_upstream_raw_request",
+                side_effect=AssertionError(
+                    "HTTP upstream transport should not be used when websocket upstream mode is enabled"
+                ),
+            ),
+        ):
+            mock_bridge.return_value = make_json_response(
+                {"error": {"message": "Upstream websocket event payload was not a JSON object"}},
+                status_code=502,
+            )
+
+            response = client.post(
+                "/v1/responses",
+                json={"model": "gpt-5.4", "input": "hello"},
+            )
+
+        body = response.get_json()
+        self.assertEqual(response.status_code, 502)
+        self.assertEqual(body["error"]["message"], "Upstream websocket event payload was not a JSON object")
+        mock_bridge.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -880,7 +880,13 @@ class ResponsesWebsocketUpstreamContractTests(unittest.TestCase):
 
         self.assertEqual(first.status_code, 200)
         self.assertEqual(second.status_code, 200)
+        first_payload = json.loads(first_upstream.sent[0])
+        self.assertEqual(first_payload["type"], "response.create")
+        self.assertEqual(first_payload["model"], "gpt-5.4")
+        self.assertNotIn("previous_response_id", first_payload)
         second_payload = json.loads(second_upstream.sent[0])
+        self.assertEqual(second_payload["type"], "response.create")
+        self.assertEqual(second_payload["model"], "gpt-5.4")
         self.assertNotIn("previous_response_id", second_payload)
         self.assertEqual(
             second_payload["input"],
@@ -1013,6 +1019,63 @@ class ResponsesWebsocketBridgeTests(unittest.TestCase):
             "Upstream websocket response.completed event is missing a response object",
         ):
             responses_websocket_bridge.parse_upstream_websocket_event('{"type":"response.completed"}')
+
+    def test_build_upstream_request_event_keeps_existing_response_create_payload(self) -> None:
+        payload = {"type": "response.create", "model": "gpt-5.4", "input": "hello", "stream": True}
+
+        self.assertIs(
+            responses_websocket_bridge._build_upstream_request_event(payload),
+            payload,
+        )
+
+    @patch("chatmock.responses_websocket_bridge.get_effective_chatgpt_auth", return_value=("token", "acct"))
+    @patch("chatmock.responses_websocket_bridge.connect_upstream_websocket")
+    def test_bridge_promotes_plain_http_payload_to_top_level_response_create_fields(self, mock_connect, _mock_auth) -> None:
+        class FakeUpstreamWebsocket:
+            def __init__(self) -> None:
+                self.sent: list[str] = []
+                self._messages = [
+                    json.dumps({"type": "response.created", "response": {"id": "resp_ws_1", "object": "response", "status": "in_progress"}}),
+                    json.dumps({"type": "response.completed", "response": {"id": "resp_ws_1", "object": "response", "status": "completed", "output": []}}),
+                ]
+
+            def send(self, message: str) -> None:
+                self.sent.append(message)
+
+            def recv(self) -> str:
+                return self._messages.pop(0)
+
+            def close(self) -> None:
+                return None
+
+        fake_upstream = FakeUpstreamWebsocket()
+        mock_connect.return_value = fake_upstream
+        payload = {
+            "model": "gpt-5.4",
+            "input": [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "hello"}],
+                }
+            ],
+            "stream": True,
+        }
+
+        with self.app.test_request_context("/v1/responses", method="POST"):
+            response = responses_websocket_bridge.send_responses_request_via_websocket(
+                payload=payload,
+                session_id="session-fixed",
+                stream=False,
+            )
+
+        outbound = json.loads(fake_upstream.sent[0])
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(outbound["type"], "response.create")
+        self.assertEqual(outbound["model"], payload["model"])
+        self.assertEqual(outbound["input"], payload["input"])
+        self.assertTrue(outbound["stream"])
+        self.assertNotIn("response", outbound)
 
     @patch("chatmock.responses_websocket_bridge.get_effective_chatgpt_auth", return_value=("token", "acct"))
     @patch("chatmock.responses_websocket_bridge.connect_upstream_websocket")

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1128,6 +1128,67 @@ class ResponsesWebsocketUpstreamStatefulContractTests(unittest.TestCase):
         self.app.config["RESPONSES_WEBSOCKET_UPSTREAM_STATEFUL"] = True
         self.client = self.app.test_client()
 
+    def test_stateful_mode_enables_route_level_previous_response_id_policy(self) -> None:
+        prepared_payload = {
+            "model": "gpt-5.4",
+            "input": [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "second"}],
+                }
+            ],
+            "instructions": "base instructions",
+            "reasoning": {"effort": "medium", "summary": "auto"},
+            "include": ["reasoning.encrypted_content"],
+            "store": False,
+            "prompt_cache_key": "session-fixed",
+            "previous_response_id": "resp_stateful_1",
+        }
+
+        with (
+            patch(
+                "chatmock.routes_openai.prepare_responses_request_for_session",
+                return_value=SimpleNamespace(payload=prepared_payload, session_id="session-fixed"),
+            ) as mock_prepare,
+            patch(
+                "chatmock.routes_openai.responses_websocket_bridge.send_responses_request_via_websocket"
+            ) as mock_bridge,
+            patch(
+                "chatmock.routes_openai.start_upstream_raw_request",
+                side_effect=AssertionError(
+                    "HTTP upstream transport should not be used when websocket upstream mode is enabled"
+                ),
+            ),
+        ):
+            mock_bridge.return_value = make_json_response(
+                {
+                    "id": "resp_ws_stateful_nonstream",
+                    "object": "response",
+                    "status": "completed",
+                    "output": [],
+                }
+            )
+
+            response = self.client.post(
+                "/v1/responses",
+                json={
+                    "model": "gpt-5.4",
+                    "previous_response_id": "resp_client_supplied",
+                    "input": "hello",
+                },
+                headers={"X-Session-Id": "session-fixed"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        mock_prepare.assert_called_once()
+        self.assertEqual(mock_prepare.call_args.args[0], "session-fixed")
+        self.assertTrue(mock_prepare.call_args.kwargs["allow_previous_response_id"])
+        self.assertEqual(
+            mock_bridge.call_args.kwargs["payload"]["previous_response_id"],
+            "resp_stateful_1",
+        )
+
     def test_stateful_mode_reuses_retained_websocket_for_non_stream_follow_up(self) -> None:
         fake_upstream = FakeUpstreamWebsocket(
             [
@@ -1431,6 +1492,36 @@ class ResponsesWebsocketUpstreamStatefulContractTests(unittest.TestCase):
                 "/v1/responses",
                 json={"model": "gpt-5.4", "input": "hello"},
                 headers={"X-Session-Id": "   "},
+            )
+
+        body = response.get_json()
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("X-Session-Id", body["error"]["message"])
+
+    def test_stateful_mode_rejects_missing_explicit_session_id_before_any_transport_layer(self) -> None:
+        with (
+            patch(
+                "chatmock.routes_openai.start_upstream_raw_request",
+                side_effect=AssertionError(
+                    "HTTP upstream transport should not be used when websocket upstream mode is enabled"
+                ),
+            ),
+            patch(
+                "chatmock.responses_websocket_bridge.get_effective_chatgpt_auth",
+                side_effect=AssertionError(
+                    "Stateful missing session-id requests must be rejected before bridge auth lookup"
+                ),
+            ),
+            patch(
+                "chatmock.responses_websocket_bridge.connect_upstream_websocket",
+                side_effect=AssertionError(
+                    "Stateful missing session-id requests must be rejected before websocket connect"
+                ),
+            ),
+        ):
+            response = self.client.post(
+                "/v1/responses",
+                json={"model": "gpt-5.4", "input": "hello"},
             )
 
         body = response.get_json()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 
 from chatmock import responses_websocket_bridge
 from chatmock.app import create_app
+from chatmock.responses_api import normalize_responses_payload
 from chatmock.session import reset_session_state
 from flask import Response
 from websockets.sync.client import connect as ws_connect
@@ -64,6 +65,22 @@ class RouteTests(unittest.TestCase):
         reset_session_state()
         self.app = create_app()
         self.client = self.app.test_client()
+
+    def test_normalize_responses_payload_defaults_store_false_when_omitted(self) -> None:
+        normalized = normalize_responses_payload(
+            {"model": "gpt-5.4", "input": "hello"},
+            config=self.app.config,
+        )
+
+        self.assertEqual(normalized.payload["store"], False)
+
+    def test_normalize_responses_payload_forces_store_false_when_explicit_true(self) -> None:
+        normalized = normalize_responses_payload(
+            {"model": "gpt-5.4", "input": "hello", "store": True},
+            config=self.app.config,
+        )
+
+        self.assertEqual(normalized.payload["store"], False)
 
     def test_create_app_defaults_responses_websocket_upstream_disabled(self) -> None:
         self.assertFalse(self.app.config["RESPONSES_WEBSOCKET_UPSTREAM"])
@@ -273,6 +290,39 @@ class RouteTests(unittest.TestCase):
         self.assertIsInstance(outbound_payload["prompt_cache_key"], str)
 
     @patch("chatmock.routes_openai.start_upstream_raw_request")
+    def test_responses_route_forces_explicit_store_true_to_false(self, mock_start) -> None:
+        mock_start.return_value = (
+            FakeUpstream(
+                [
+                    {
+                        "type": "response.created",
+                        "response": {"id": "resp_store", "object": "response", "status": "in_progress"},
+                    },
+                    {
+                        "type": "response.completed",
+                        "response": {
+                            "id": "resp_store",
+                            "object": "response",
+                            "status": "completed",
+                            "output": [],
+                        },
+                    },
+                ],
+                headers={"Content-Type": "text/event-stream"},
+            ),
+            None,
+        )
+
+        response = self.client.post(
+            "/v1/responses",
+            json={"model": "gpt5.4-mini", "input": "hello", "store": True},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        outbound_payload = mock_start.call_args.args[0]
+        self.assertEqual(outbound_payload["store"], False)
+
+    @patch("chatmock.routes_openai.start_upstream_raw_request")
     def test_responses_route_honors_debug_model_override(self, mock_start) -> None:
         app = create_app(debug_model="gpt-5.4")
         client = app.test_client()
@@ -387,6 +437,7 @@ class RouteTests(unittest.TestCase):
             "/v1/responses",
             json={
                 "model": "gpt-5.4",
+                "previous_response_id": "resp_client_supplied",
                 "input": [
                     {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hello"}]},
                     {"type": "message", "role": "assistant", "id": "msg_1", "content": [{"type": "output_text", "text": "assistant output"}]},
@@ -1143,10 +1194,47 @@ class ResponsesWebsocketBridgeTests(unittest.TestCase):
                 stream=True,
             )
 
+        body = response.get_data(as_text=True)
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.content_type.startswith("text/event-stream"))
-        self.assertIn("response.output_text.delta", response.get_data(as_text=True))
-        self.assertIn("data: [DONE]", response.get_data(as_text=True))
+        self.assertIn("response.output_text.delta", body)
+        self.assertIn('data: {"type":"response.completed","response":{"id":"resp_ws_1","output":[]}}', body)
+        self.assertNotIn("data: [DONE]", body)
+
+    @patch("chatmock.responses_websocket_bridge.get_effective_chatgpt_auth", return_value=("token", "acct"))
+    @patch("chatmock.responses_websocket_bridge.connect_upstream_websocket")
+    def test_bridge_stops_after_protocol_error_event_without_done_sentinel(self, mock_connect, _mock_auth) -> None:
+        class FakeUpstreamWebsocket:
+            def __init__(self) -> None:
+                self._messages = [
+                    json.dumps({"type": "response.created", "response": {"id": "resp_ws_1"}}),
+                    json.dumps({"type": "response.completed"}),
+                ]
+
+            def send(self, message: str) -> None:
+                return None
+
+            def recv(self) -> str:
+                return self._messages.pop(0)
+
+            def close(self) -> None:
+                return None
+
+        mock_connect.return_value = FakeUpstreamWebsocket()
+
+        with self.app.test_request_context("/v1/responses", method="POST"):
+            response = responses_websocket_bridge.send_responses_request_via_websocket(
+                payload={"type": "response.create", "model": "gpt-5.4", "stream": True},
+                session_id="session-fixed",
+                stream=True,
+            )
+
+        body = response.get_data(as_text=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.content_type.startswith("text/event-stream"))
+        self.assertIn('data: {"type":"response.created","response":{"id":"resp_ws_1"}}', body)
+        self.assertIn('data: {"type":"error","status_code":502,"error":{"message":"Upstream websocket response.completed event is missing a response object"}}', body)
+        self.assertNotIn("data: [DONE]", body)
 
 
 if __name__ == "__main__":

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1513,7 +1513,16 @@ class ResponsesWebsocketUpstreamStatefulContractTests(unittest.TestCase):
 
         body = response.get_json()
         self.assertEqual(response.status_code, 400)
+        self.assertEqual(body.get("code"), "previous_response_not_found")
+        self.assertEqual(
+            body.get("message"),
+            "No response found for previous_response_id resp_missing_stateful_marker.",
+        )
         self.assertEqual(body.get("error", {}).get("code"), "previous_response_not_found")
+        self.assertEqual(
+            body.get("error", {}).get("message"),
+            "No response found for previous_response_id resp_missing_stateful_marker.",
+        )
 
     def test_stateful_mode_returns_retryable_previous_response_not_found_for_lost_retained_socket(self) -> None:
         first_upstream = FakeUpstreamWebsocket(

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -53,6 +53,23 @@ class FakeUpstream:
         return None
 
 
+class FakeUpstreamWebsocket:
+    def __init__(self, messages: list[str]) -> None:
+        self.sent: list[str] = []
+        self.close_calls = 0
+        self._messages = list(messages)
+
+    def send(self, message: str) -> None:
+        self.sent.append(message)
+
+    def recv(self) -> str:
+        return self._messages.pop(0)
+
+    def close(self) -> None:
+        self.close_calls += 1
+        return None
+
+
 def make_json_response(body: dict[str, object], *, status_code: int = 200) -> Response:
     return Response(json.dumps(body), status=status_code, mimetype="application/json")
 
@@ -1102,6 +1119,419 @@ class ResponsesWebsocketUpstreamContractTests(unittest.TestCase):
         self.assertEqual(response.status_code, 502)
         self.assertEqual(body["error"]["message"], "Upstream websocket event payload was not a JSON object")
         mock_bridge.assert_called_once()
+
+
+class ResponsesWebsocketUpstreamStatefulContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        reset_session_state()
+        self.app = create_app(responses_websocket_upstream=True)
+        self.app.config["RESPONSES_WEBSOCKET_UPSTREAM_STATEFUL"] = True
+        self.client = self.app.test_client()
+
+    def test_stateful_mode_reuses_retained_websocket_for_non_stream_follow_up(self) -> None:
+        fake_upstream = FakeUpstreamWebsocket(
+            [
+                json.dumps(
+                    {
+                        "type": "response.created",
+                        "response": {"id": "resp_stateful_1", "object": "response", "status": "in_progress"},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "response.completed",
+                        "response": {
+                            "id": "resp_stateful_1",
+                            "object": "response",
+                            "status": "completed",
+                            "output": [
+                                {
+                                    "type": "message",
+                                    "role": "assistant",
+                                    "id": "msg_stateful_1",
+                                    "content": [{"type": "output_text", "text": "assistant output"}],
+                                }
+                            ],
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "response.created",
+                        "response": {"id": "resp_stateful_2", "object": "response", "status": "in_progress"},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "response.completed",
+                        "response": {
+                            "id": "resp_stateful_2",
+                            "object": "response",
+                            "status": "completed",
+                            "output": [],
+                        },
+                    }
+                ),
+            ]
+        )
+
+        with (
+            patch("chatmock.responses_websocket_bridge.get_effective_chatgpt_auth", return_value=("token", "acct")),
+            patch("chatmock.responses_websocket_bridge.connect_upstream_websocket", return_value=fake_upstream) as mock_connect,
+            patch(
+                "chatmock.routes_openai.start_upstream_raw_request",
+                side_effect=AssertionError(
+                    "HTTP upstream transport should not be used when websocket upstream mode is enabled"
+                ),
+            ),
+        ):
+            headers = {"X-Session-Id": "session-fixed"}
+            first = self.client.post(
+                "/v1/responses",
+                json={"model": "gpt-5.4", "input": "hello"},
+                headers=headers,
+            )
+            second = self.client.post(
+                "/v1/responses",
+                json={
+                    "model": "gpt-5.4",
+                    "input": [
+                        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hello"}]},
+                        {
+                            "type": "message",
+                            "role": "assistant",
+                            "id": "msg_stateful_1",
+                            "content": [{"type": "output_text", "text": "assistant output"}],
+                        },
+                        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "second"}]},
+                    ],
+                },
+                headers=headers,
+            )
+
+        self.assertEqual(first.status_code, 200)
+        self.assertEqual(second.status_code, 200)
+        self.assertEqual(mock_connect.call_count, 1)
+        follow_up_payload = json.loads(fake_upstream.sent[1])
+        self.assertEqual(follow_up_payload["previous_response_id"], "resp_stateful_1")
+        self.assertEqual(
+            follow_up_payload["input"],
+            [{"type": "message", "role": "user", "content": [{"type": "input_text", "text": "second"}]}],
+        )
+
+    def test_stateful_mode_reuses_retained_websocket_for_streaming_follow_up(self) -> None:
+        fake_upstream = FakeUpstreamWebsocket(
+            [
+                json.dumps({"type": "response.created", "response": {"id": "resp_stream_stateful_1"}}),
+                json.dumps(
+                    {
+                        "type": "response.output_item.done",
+                        "item": {
+                            "type": "message",
+                            "role": "assistant",
+                            "id": "msg_stream_stateful_1",
+                            "content": [{"type": "output_text", "text": "assistant output"}],
+                        },
+                    }
+                ),
+                json.dumps({"type": "response.completed", "response": {"id": "resp_stream_stateful_1", "output": []}}),
+                json.dumps({"type": "response.created", "response": {"id": "resp_stream_stateful_2"}}),
+                json.dumps({"type": "response.output_text.delta", "delta": "follow-up"}),
+                json.dumps({"type": "response.completed", "response": {"id": "resp_stream_stateful_2", "output": []}}),
+            ]
+        )
+
+        with (
+            patch("chatmock.responses_websocket_bridge.get_effective_chatgpt_auth", return_value=("token", "acct")),
+            patch("chatmock.responses_websocket_bridge.connect_upstream_websocket", return_value=fake_upstream) as mock_connect,
+            patch(
+                "chatmock.routes_openai.start_upstream_raw_request",
+                side_effect=AssertionError(
+                    "HTTP upstream transport should not be used when websocket upstream mode is enabled"
+                ),
+            ),
+        ):
+            headers = {"X-Session-Id": "session-fixed"}
+            first = self.client.post(
+                "/v1/responses",
+                json={"model": "gpt-5.4", "input": "hello", "stream": True},
+                headers=headers,
+            )
+            second = self.client.post(
+                "/v1/responses",
+                json={
+                    "model": "gpt-5.4",
+                    "stream": True,
+                    "input": [
+                        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hello"}]},
+                        {
+                            "type": "message",
+                            "role": "assistant",
+                            "id": "msg_stream_stateful_1",
+                            "content": [{"type": "output_text", "text": "assistant output"}],
+                        },
+                        {
+                            "type": "message",
+                            "role": "user",
+                            "content": [{"type": "input_text", "text": "stream follow-up"}],
+                        },
+                    ],
+                },
+                headers=headers,
+            )
+
+        self.assertEqual(first.status_code, 200)
+        self.assertEqual(second.status_code, 200)
+        self.assertEqual(mock_connect.call_count, 1)
+        self.assertTrue(second.content_type.startswith("text/event-stream"))
+        self.assertIn("response.output_text.delta", second.get_data(as_text=True))
+        follow_up_payload = json.loads(fake_upstream.sent[1])
+        self.assertEqual(follow_up_payload["previous_response_id"], "resp_stream_stateful_1")
+        self.assertEqual(
+            follow_up_payload["input"],
+            [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "stream follow-up"}],
+                }
+            ],
+        )
+
+    def test_stateful_mode_keeps_explicit_previous_response_id_and_resets_retained_session(self) -> None:
+        first_upstream = FakeUpstreamWebsocket(
+            [
+                json.dumps(
+                    {
+                        "type": "response.created",
+                        "response": {"id": "resp_stateful_reset_1", "object": "response", "status": "in_progress"},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "response.completed",
+                        "response": {
+                            "id": "resp_stateful_reset_1",
+                            "object": "response",
+                            "status": "completed",
+                            "output": [
+                                {
+                                    "type": "message",
+                                    "role": "assistant",
+                                    "id": "msg_stateful_reset_1",
+                                    "content": [{"type": "output_text", "text": "assistant output"}],
+                                }
+                            ],
+                        },
+                    }
+                ),
+            ]
+        )
+        second_upstream = FakeUpstreamWebsocket(
+            [
+                json.dumps(
+                    {
+                        "type": "response.created",
+                        "response": {"id": "resp_stateful_reset_2", "object": "response", "status": "in_progress"},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "response.completed",
+                        "response": {
+                            "id": "resp_stateful_reset_2",
+                            "object": "response",
+                            "status": "completed",
+                            "output": [],
+                        },
+                    }
+                ),
+            ]
+        )
+
+        with (
+            patch("chatmock.responses_websocket_bridge.get_effective_chatgpt_auth", return_value=("token", "acct")),
+            patch(
+                "chatmock.responses_websocket_bridge.connect_upstream_websocket",
+                side_effect=[first_upstream, second_upstream],
+            ) as mock_connect,
+            patch(
+                "chatmock.routes_openai.start_upstream_raw_request",
+                side_effect=AssertionError(
+                    "HTTP upstream transport should not be used when websocket upstream mode is enabled"
+                ),
+            ),
+        ):
+            headers = {"X-Session-Id": "session-fixed"}
+            first = self.client.post(
+                "/v1/responses",
+                json={"model": "gpt-5.4", "input": "hello"},
+                headers=headers,
+            )
+            second = self.client.post(
+                "/v1/responses",
+                json={
+                    "model": "gpt-5.4",
+                    "previous_response_id": "resp_client_reset",
+                    "input": [
+                        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hello"}]},
+                        {
+                            "type": "message",
+                            "role": "assistant",
+                            "id": "msg_stateful_reset_1",
+                            "content": [{"type": "output_text", "text": "assistant output"}],
+                        },
+                        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "second"}]},
+                    ],
+                },
+                headers=headers,
+            )
+
+        self.assertEqual(first.status_code, 200)
+        self.assertEqual(second.status_code, 200)
+        self.assertEqual(mock_connect.call_count, 2)
+        follow_up_payload = json.loads(second_upstream.sent[0])
+        self.assertEqual(follow_up_payload["previous_response_id"], "resp_client_reset")
+        self.assertEqual(
+            follow_up_payload["input"],
+            [
+                {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hello"}]},
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "id": "msg_stateful_reset_1",
+                    "content": [{"type": "output_text", "text": "assistant output"}],
+                },
+                {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "second"}]},
+            ],
+        )
+
+    def test_stateful_mode_rejects_invalid_explicit_session_id_before_any_transport_layer(self) -> None:
+        with (
+            patch(
+                "chatmock.routes_openai.start_upstream_raw_request",
+                side_effect=AssertionError(
+                    "HTTP upstream transport should not be used when websocket upstream mode is enabled"
+                ),
+            ),
+            patch(
+                "chatmock.responses_websocket_bridge.get_effective_chatgpt_auth",
+                side_effect=AssertionError(
+                    "Stateful invalid session-id requests must be rejected before bridge auth lookup"
+                ),
+            ),
+            patch(
+                "chatmock.responses_websocket_bridge.connect_upstream_websocket",
+                side_effect=AssertionError(
+                    "Stateful invalid session-id requests must be rejected before websocket connect"
+                ),
+            ),
+        ):
+            response = self.client.post(
+                "/v1/responses",
+                json={"model": "gpt-5.4", "input": "hello"},
+                headers={"X-Session-Id": "   "},
+            )
+
+        body = response.get_json()
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("X-Session-Id", body["error"]["message"])
+
+    def test_stateful_mode_rejects_same_session_contention_with_conflict(self) -> None:
+        first_request_started = threading.Event()
+        release_first_request = threading.Event()
+        first_response: dict[str, Response] = {}
+        thread_errors: list[BaseException] = []
+
+        class BlockingUpstreamWebsocket(FakeUpstreamWebsocket):
+            def __init__(self) -> None:
+                super().__init__(
+                    [
+                        json.dumps({"type": "response.created", "response": {"id": "resp_stateful_inflight_1"}}),
+                        json.dumps(
+                            {
+                                "type": "response.completed",
+                                "response": {"id": "resp_stateful_inflight_1", "output": []},
+                            }
+                        ),
+                    ]
+                )
+                self._blocked = False
+
+            def recv(self) -> str:
+                if not self._blocked:
+                    self._blocked = True
+                    first_request_started.set()
+                    if not release_first_request.wait(timeout=2):
+                        raise AssertionError("First stateful request did not reach the blocking point")
+                return super().recv()
+
+        first_upstream = BlockingUpstreamWebsocket()
+        second_upstream = FakeUpstreamWebsocket(
+            [
+                json.dumps({"type": "response.created", "response": {"id": "resp_stateful_inflight_2"}}),
+                json.dumps(
+                    {
+                        "type": "response.completed",
+                        "response": {"id": "resp_stateful_inflight_2", "output": []},
+                    }
+                ),
+            ]
+        )
+
+        def send_first_request() -> None:
+            try:
+                with self.app.test_client() as client:
+                    first_response["response"] = client.post(
+                        "/v1/responses",
+                        json={"model": "gpt-5.4", "input": "hello"},
+                        headers={"X-Session-Id": "session-fixed"},
+                    )
+            except BaseException as exc:  # pragma: no cover - assertion plumbing for the worker thread
+                thread_errors.append(exc)
+
+        with (
+            patch("chatmock.responses_websocket_bridge.get_effective_chatgpt_auth", return_value=("token", "acct")),
+            patch(
+                "chatmock.responses_websocket_bridge.connect_upstream_websocket",
+                side_effect=[first_upstream, second_upstream],
+            ),
+            patch(
+                "chatmock.routes_openai.start_upstream_raw_request",
+                side_effect=AssertionError(
+                    "HTTP upstream transport should not be used when websocket upstream mode is enabled"
+                ),
+            ),
+        ):
+            first_thread = threading.Thread(target=send_first_request)
+            first_thread.start()
+            self.assertTrue(
+                first_request_started.wait(timeout=1),
+                "First stateful request did not block before issuing the contention request",
+            )
+
+            second = self.client.post(
+                "/v1/responses",
+                json={"model": "gpt-5.4", "input": "second"},
+                headers={"X-Session-Id": "session-fixed"},
+            )
+
+            release_first_request.set()
+            first_thread.join(timeout=2)
+
+        if thread_errors:
+            raise thread_errors[0]
+        self.assertFalse(first_thread.is_alive(), "First stateful request thread did not finish")
+        self.assertEqual(first_response["response"].status_code, 200)
+        self.assertEqual(second.status_code, 409)
+        self.assertIn("already in progress", second.get_json()["error"]["message"])
+
+    def test_stateful_mode_requires_websocket_upstream_at_startup(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError,
+            "RESPONSES_WEBSOCKET_UPSTREAM_STATEFUL requires RESPONSES_WEBSOCKET_UPSTREAM",
+        ):
+            create_app(responses_websocket_upstream_stateful=True)
 
 
 class ResponsesWebsocketBridgeTests(unittest.TestCase):

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -309,6 +309,61 @@ class RouteTests(unittest.TestCase):
         self.assertIsInstance(outbound_payload["prompt_cache_key"], str)
 
     @patch("chatmock.routes_openai.start_upstream_raw_request")
+    def test_responses_route_backfills_completed_response_output_from_output_item_done_events(
+        self,
+        mock_start,
+    ) -> None:
+        mock_start.return_value = (
+            FakeUpstream(
+                [
+                    {
+                        "type": "response.created",
+                        "response": {"id": "resp_output_backfill", "object": "response", "status": "in_progress"},
+                    },
+                    {
+                        "type": "response.output_item.done",
+                        "item": {
+                            "type": "message",
+                            "role": "assistant",
+                            "id": "msg_output_backfill",
+                            "content": [{"type": "output_text", "text": "assistant output"}],
+                        },
+                    },
+                    {
+                        "type": "response.completed",
+                        "response": {
+                            "id": "resp_output_backfill",
+                            "object": "response",
+                            "status": "completed",
+                            "output": [],
+                        },
+                    },
+                ],
+                headers={"Content-Type": "text/event-stream"},
+            ),
+            None,
+        )
+
+        response = self.client.post(
+            "/v1/responses",
+            json={"model": "gpt5.4-mini", "input": "hello"},
+        )
+
+        body = response.get_json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            body["output"],
+            [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "id": "msg_output_backfill",
+                    "content": [{"type": "output_text", "text": "assistant output"}],
+                }
+            ],
+        )
+
+    @patch("chatmock.routes_openai.start_upstream_raw_request")
     def test_responses_route_forces_explicit_store_true_to_false(self, mock_start) -> None:
         mock_start.return_value = (
             FakeUpstream(
@@ -1622,6 +1677,100 @@ class ResponsesWebsocketUpstreamStatefulContractTests(unittest.TestCase):
         self.assertEqual(second.status_code, 409)
         self.assertIn("already in progress", second.get_json()["error"]["message"])
 
+    def test_stateful_mode_applies_route_level_retained_session_capacity_limit(self) -> None:
+        first_request_started = threading.Event()
+        release_first_request = threading.Event()
+        first_response: dict[str, Response] = {}
+        thread_errors: list[BaseException] = []
+        self.app.config["RESPONSES_WEBSOCKET_UPSTREAM_MAX_RETAINED_SESSIONS"] = 1
+
+        class BlockingUpstreamWebsocket(FakeUpstreamWebsocket):
+            def __init__(self) -> None:
+                super().__init__(
+                    [
+                        json.dumps({"type": "response.created", "response": {"id": "resp_stateful_capacity_1"}}),
+                        json.dumps(
+                            {
+                                "type": "response.completed",
+                                "response": {"id": "resp_stateful_capacity_1", "output": []},
+                            }
+                        ),
+                    ]
+                )
+                self._blocked = False
+
+            def recv(self) -> str:
+                if not self._blocked:
+                    self._blocked = True
+                    first_request_started.set()
+                    if not release_first_request.wait(timeout=2):
+                        raise AssertionError("First stateful request did not reach the blocking point")
+                return super().recv()
+
+        second_upstream = FakeUpstreamWebsocket(
+            [
+                json.dumps({"type": "response.created", "response": {"id": "resp_stateful_capacity_2"}}),
+                json.dumps(
+                    {
+                        "type": "response.completed",
+                        "response": {"id": "resp_stateful_capacity_2", "output": []},
+                    }
+                ),
+            ]
+        )
+
+        def send_first_request() -> None:
+            try:
+                with self.app.test_client() as client:
+                    first_response["response"] = client.post(
+                        "/v1/responses",
+                        json={"model": "gpt-5.4", "input": "hello"},
+                        headers={"X-Session-Id": "session-1"},
+                    )
+            except BaseException as exc:  # pragma: no cover - assertion plumbing for the worker thread
+                thread_errors.append(exc)
+
+        with (
+            patch("chatmock.responses_websocket_bridge.get_effective_chatgpt_auth", return_value=("token", "acct")),
+            patch(
+                "chatmock.responses_websocket_bridge.connect_upstream_websocket",
+                side_effect=[BlockingUpstreamWebsocket(), second_upstream],
+            ) as mock_connect,
+            patch(
+                "chatmock.routes_openai.start_upstream_raw_request",
+                side_effect=AssertionError(
+                    "HTTP upstream transport should not be used when websocket upstream mode is enabled"
+                ),
+            ),
+        ):
+            first_thread = threading.Thread(target=send_first_request)
+            first_thread.start()
+            self.assertTrue(
+                first_request_started.wait(timeout=1),
+                "First stateful request did not block before issuing the capacity request",
+            )
+
+            second = self.client.post(
+                "/v1/responses",
+                json={"model": "gpt-5.4", "input": "second"},
+                headers={"X-Session-Id": "session-2"},
+            )
+
+            release_first_request.set()
+            first_thread.join(timeout=2)
+
+        if thread_errors:
+            raise thread_errors[0]
+
+        self.assertFalse(first_thread.is_alive(), "First stateful request thread did not finish")
+        self.assertEqual(first_response["response"].status_code, 200)
+        self.assertEqual(second.status_code, 503)
+        self.assertEqual(
+            second.get_json()["error"]["message"],
+            "Too many retained upstream websocket sessions are active right now.",
+        )
+        self.assertEqual(mock_connect.call_count, 1)
+
     def test_stateful_mode_requires_websocket_upstream_at_startup(self) -> None:
         with self.assertRaisesRegex(
             ValueError,
@@ -1755,6 +1904,81 @@ class ResponsesWebsocketBridgeTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(body["id"], "resp_ws_1")
         self.assertEqual(json.loads(fake_upstream.sent[0])["model"], "gpt-5.4")
+        self.assertEqual(fake_upstream.close_calls, 1)
+        mock_note_final_response.assert_called_once_with("session-fixed", body)
+
+    @patch("chatmock.responses_websocket_bridge.get_effective_chatgpt_auth", return_value=("token", "acct"))
+    @patch("chatmock.responses_websocket_bridge.connect_upstream_websocket")
+    @patch("chatmock.responses_websocket_bridge.note_responses_final_response")
+    def test_bridge_backfills_completed_response_output_from_output_item_done_events(
+        self,
+        mock_note_final_response,
+        mock_connect,
+        _mock_auth,
+    ) -> None:
+        class FakeUpstreamWebsocket:
+            def __init__(self) -> None:
+                self.sent: list[str] = []
+                self.close_calls = 0
+                self._messages = [
+                    json.dumps({"type": "response.created", "response": {"id": "resp_ws_1", "object": "response", "status": "in_progress"}}),
+                    json.dumps(
+                        {
+                            "type": "response.output_item.done",
+                            "item": {
+                                "type": "message",
+                                "role": "assistant",
+                                "id": "msg_ws_1",
+                                "content": [{"type": "output_text", "text": "assistant output"}],
+                            },
+                        }
+                    ),
+                    json.dumps(
+                        {
+                            "type": "response.completed",
+                            "response": {
+                                "id": "resp_ws_1",
+                                "object": "response",
+                                "status": "completed",
+                                "output": [],
+                            },
+                        }
+                    ),
+                ]
+
+            def send(self, message: str) -> None:
+                self.sent.append(message)
+
+            def recv(self) -> str:
+                return self._messages.pop(0)
+
+            def close(self) -> None:
+                self.close_calls += 1
+                return None
+
+        fake_upstream = FakeUpstreamWebsocket()
+        mock_connect.return_value = fake_upstream
+
+        with self.app.test_request_context("/v1/responses", method="POST"):
+            response = responses_websocket_bridge.send_responses_request_via_websocket(
+                payload={"type": "response.create", "model": "gpt-5.4", "stream": True},
+                session_id="session-fixed",
+                stream=False,
+            )
+
+        body = response.get_json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            body["output"],
+            [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "id": "msg_ws_1",
+                    "content": [{"type": "output_text", "text": "assistant output"}],
+                }
+            ],
+        )
         self.assertEqual(fake_upstream.close_calls, 1)
         mock_note_final_response.assert_called_once_with("session-fixed", body)
 


### PR DESCRIPTION
## Summary

- add an opt-in websocket upstream bridge for the HTTP /v1/responses route
- add stateful follow-up support by retaining websocket sessions behind marker-based previous_response_id reuse
- fix thin response.completed payloads so strict consumers such as VS Code do not fail on missing output arrays

## Details

- wire new app, CLI, and env configuration for websocket-upstream and stateful modes
- bridge websocket upstream events back to HTTP clients for both streaming and non-stream responses
- normalize terminal completed payloads by backfilling response.output from collected items, or an empty array when the upstream omits it
- add retained-session handling for follow-ups, including stale-marker, conflict, and capacity cases
- document the new modes and operator configuration in the README and Docker docs

## Testing

- add regression coverage for route contracts, websocket session retention, and CLI wiring
- cover transport-only bridging, stateful follow-ups, stale/conflict handling, and strict completed-payload compatibility

## Notes

- the feature remains opt-in
- stateful retention is process-local
- streaming invalid-marker behavior is documented and unchanged by this PR